### PR TITLE
feat: Catalog API — GET /api/v1/datasets list and detail

### DIFF
--- a/apps/golang/backend/cmd/api/main.go
+++ b/apps/golang/backend/cmd/api/main.go
@@ -66,6 +66,7 @@ func main() {
 	moduleTypeRepo := db.NewModuleTypeRepo(sqlDB)
 	moduleTypeSchemaRepo := db.NewModuleTypeSchemaRepo(sqlDB)
 	connectionRepo := db.NewConnectionRepo(sqlDB)
+	datasetRepo := db.NewDatasetRepo(sqlDB)
 	adminAuditLogRepo := db.NewAdminAuditLogRepo(sqlDB)
 	txManager := db.NewTxManager(sqlDB)
 
@@ -81,6 +82,7 @@ func main() {
 	jobService := usecase.NewJobService(jobRepo, jobVersionRepo, jobModuleRepo, jobModuleEdgeRepo, txManager)
 	moduleTypeService := usecase.NewModuleTypeService(moduleTypeRepo, moduleTypeSchemaRepo)
 	connectionService := usecase.NewConnectionService(connectionRepo)
+	datasetService := usecase.NewDatasetService(datasetRepo)
 	eventService := usecase.NewEventService(eventQueue)
 	eventMetrics := observability.NewEventMetrics()
 	adminTenantService := usecase.NewAdminTenantService(tenantRepo, adminAuditLogRepo)
@@ -92,6 +94,7 @@ func main() {
 	jobH := handler.NewJobHandler(jobService)
 	moduleTypeH := handler.NewModuleTypeHandler(moduleTypeService)
 	connectionH := handler.NewConnectionHandler(connectionService)
+	datasetH := handler.NewDatasetHandler(datasetService)
 	eventH := handler.NewEventHandler(eventService, eventMetrics)
 	adminTenantH := handler.NewAdminTenantHandler(adminTenantService)
 
@@ -153,6 +156,10 @@ func main() {
 	mux.Handle("GET /api/v1/connections/{id}", protected(connectionH.Get))
 	mux.Handle("PUT /api/v1/connections/{id}", protected(connectionH.Update))
 	mux.Handle("DELETE /api/v1/connections/{id}", protected(connectionH.Delete))
+
+	// Datasets
+	mux.Handle("GET /api/v1/datasets", protected(datasetH.List))
+	mux.Handle("GET /api/v1/datasets/{id}", protected(datasetH.Get))
 
 	// Admin tenants
 	mux.Handle("POST /api/v1/admin/tenants", adminProtected(adminTenantH.Create))

--- a/apps/golang/backend/db/dataset_repo.go
+++ b/apps/golang/backend/db/dataset_repo.go
@@ -1,0 +1,108 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/user/micro-dp/domain"
+)
+
+type DatasetRepo struct {
+	db DBTX
+}
+
+func NewDatasetRepo(db DBTX) *DatasetRepo {
+	return &DatasetRepo{db: db}
+}
+
+func scanDataset(s interface{ Scan(...any) error }) (*domain.Dataset, error) {
+	var d domain.Dataset
+	if err := s.Scan(
+		&d.ID, &d.TenantID, &d.Name, &d.SourceType,
+		&d.SchemaJSON, &d.RowCount, &d.StoragePath,
+		&d.LastUpdatedAt, &d.CreatedAt, &d.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	return &d, nil
+}
+
+func (r *DatasetRepo) FindByID(ctx context.Context, tenantID, id string) (*domain.Dataset, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT id, tenant_id, name, source_type, schema_json, row_count, storage_path, last_updated_at, created_at, updated_at
+		 FROM datasets WHERE tenant_id = ? AND id = ?`, tenantID, id,
+	)
+	d, err := scanDataset(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, domain.ErrDatasetNotFound
+		}
+		return nil, err
+	}
+	return d, nil
+}
+
+func (r *DatasetRepo) ListByTenant(ctx context.Context, tenantID string, filter domain.DatasetListFilter) ([]domain.Dataset, error) {
+	query := `SELECT id, tenant_id, name, source_type, schema_json, row_count, storage_path, last_updated_at, created_at, updated_at
+		 FROM datasets WHERE tenant_id = ?`
+	args := []any{tenantID}
+
+	if filter.Query != "" {
+		query += ` AND name LIKE ?`
+		args = append(args, fmt.Sprintf("%%%s%%", filter.Query))
+	}
+	if filter.SourceType != "" {
+		query += ` AND source_type = ?`
+		args = append(args, filter.SourceType)
+	}
+
+	query += ` ORDER BY name`
+
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	query += fmt.Sprintf(" LIMIT %d", limit)
+
+	if filter.Offset > 0 {
+		query += fmt.Sprintf(" OFFSET %d", filter.Offset)
+	}
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var datasets []domain.Dataset
+	for rows.Next() {
+		d, err := scanDataset(rows)
+		if err != nil {
+			return nil, err
+		}
+		datasets = append(datasets, *d)
+	}
+	return datasets, rows.Err()
+}
+
+func (r *DatasetRepo) Create(ctx context.Context, d *domain.Dataset) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO datasets (id, tenant_id, name, source_type, schema_json, row_count, storage_path, last_updated_at, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+		d.ID, d.TenantID, d.Name, d.SourceType, d.SchemaJSON, d.RowCount, d.StoragePath, d.LastUpdatedAt,
+	)
+	return err
+}
+
+func (r *DatasetRepo) Update(ctx context.Context, d *domain.Dataset) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE datasets SET name = ?, source_type = ?, schema_json = ?, row_count = ?, storage_path = ?, last_updated_at = ?, updated_at = datetime('now')
+		 WHERE tenant_id = ? AND id = ?`,
+		d.Name, d.SourceType, d.SchemaJSON, d.RowCount, d.StoragePath, d.LastUpdatedAt, d.TenantID, d.ID,
+	)
+	return err
+}

--- a/apps/golang/backend/db/migrations/000007_create_datasets.down.sql
+++ b/apps/golang/backend/db/migrations/000007_create_datasets.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS datasets;

--- a/apps/golang/backend/db/migrations/000007_create_datasets.up.sql
+++ b/apps/golang/backend/db/migrations/000007_create_datasets.up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE datasets (
+    id              TEXT PRIMARY KEY,
+    tenant_id       TEXT NOT NULL REFERENCES tenants(id),
+    name            TEXT NOT NULL,
+    source_type     TEXT NOT NULL CHECK(source_type IN ('tracker', 'parquet', 'import')),
+    schema_json     TEXT,
+    row_count       INTEGER,
+    storage_path    TEXT NOT NULL DEFAULT '',
+    last_updated_at DATETIME,
+    created_at      DATETIME NOT NULL DEFAULT (datetime('now')),
+    updated_at      DATETIME NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(tenant_id, name)
+);
+CREATE INDEX idx_datasets_tenant_id ON datasets(tenant_id);
+CREATE INDEX idx_datasets_source_type ON datasets(tenant_id, source_type);

--- a/apps/golang/backend/domain/dataset.go
+++ b/apps/golang/backend/domain/dataset.go
@@ -1,0 +1,42 @@
+package domain
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var ErrDatasetNotFound = errors.New("dataset not found")
+
+const (
+	SourceTypeTracker = "tracker"
+	SourceTypeParquet = "parquet"
+	SourceTypeImport  = "import"
+)
+
+type Dataset struct {
+	ID            string     `json:"id"`
+	TenantID      string     `json:"tenant_id"`
+	Name          string     `json:"name"`
+	SourceType    string     `json:"source_type"`
+	SchemaJSON    *string    `json:"schema_json,omitempty"`
+	RowCount      *int64     `json:"row_count,omitempty"`
+	StoragePath   string     `json:"storage_path"`
+	LastUpdatedAt *time.Time `json:"last_updated_at,omitempty"`
+	CreatedAt     time.Time  `json:"created_at"`
+	UpdatedAt     time.Time  `json:"updated_at"`
+}
+
+type DatasetListFilter struct {
+	Query      string
+	SourceType string
+	Limit      int
+	Offset     int
+}
+
+type DatasetRepository interface {
+	FindByID(ctx context.Context, tenantID, id string) (*Dataset, error)
+	ListByTenant(ctx context.Context, tenantID string, filter DatasetListFilter) ([]Dataset, error)
+	Create(ctx context.Context, d *Dataset) error
+	Update(ctx context.Context, d *Dataset) error
+}

--- a/apps/golang/backend/handler/convert.go
+++ b/apps/golang/backend/handler/convert.go
@@ -115,6 +115,22 @@ func toOpenAPIModuleTypeSchema(s *domain.ModuleTypeSchema) openapi.ModuleTypeSch
 	}
 }
 
+func toOpenAPIDataset(d *domain.Dataset) openapi.Dataset {
+	out := openapi.Dataset{
+		Id:          d.ID,
+		TenantId:    d.TenantID,
+		Name:        d.Name,
+		SourceType:  openapi.DatasetSourceType(d.SourceType),
+		StoragePath: d.StoragePath,
+	}
+	out.SchemaJson = d.SchemaJSON
+	out.RowCount = d.RowCount
+	out.LastUpdatedAt = d.LastUpdatedAt
+	out.CreatedAt = &d.CreatedAt
+	out.UpdatedAt = &d.UpdatedAt
+	return out
+}
+
 func toOpenAPIConnection(c *domain.Connection) openapi.Connection {
 	out := openapi.Connection{
 		Id:       c.ID,

--- a/apps/golang/backend/handler/dataset.go
+++ b/apps/golang/backend/handler/dataset.go
@@ -1,0 +1,82 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/user/micro-dp/domain"
+	"github.com/user/micro-dp/internal/openapi"
+	"github.com/user/micro-dp/usecase"
+)
+
+type DatasetHandler struct {
+	datasets *usecase.DatasetService
+}
+
+func NewDatasetHandler(datasets *usecase.DatasetService) *DatasetHandler {
+	return &DatasetHandler{datasets: datasets}
+}
+
+func (h *DatasetHandler) List(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	var filter domain.DatasetListFilter
+	filter.Query = q.Get("q")
+	filter.SourceType = q.Get("source_type")
+
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			writeError(w, http.StatusBadRequest, "invalid limit")
+			return
+		}
+		filter.Limit = n
+	}
+	if v := q.Get("offset"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			writeError(w, http.StatusBadRequest, "invalid offset")
+			return
+		}
+		filter.Offset = n
+	}
+
+	datasets, err := h.datasets.List(r.Context(), filter)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	if datasets == nil {
+		datasets = []domain.Dataset{}
+	}
+
+	items := make([]openapi.Dataset, len(datasets))
+	for i := range datasets {
+		items[i] = toOpenAPIDataset(&datasets[i])
+	}
+
+	writeJSON(w, http.StatusOK, struct {
+		Items []openapi.Dataset `json:"items"`
+	}{Items: items})
+}
+
+func (h *DatasetHandler) Get(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing id")
+		return
+	}
+
+	d, err := h.datasets.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, domain.ErrDatasetNotFound) {
+			writeError(w, http.StatusNotFound, "dataset not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toOpenAPIDataset(d))
+}

--- a/apps/golang/backend/internal/openapi/types.gen.go
+++ b/apps/golang/backend/internal/openapi/types.gen.go
@@ -20,6 +20,13 @@ const (
 	CreateModuleTypeRequestCategoryTransform   CreateModuleTypeRequestCategory = "transform"
 )
 
+// Defines values for DatasetSourceType.
+const (
+	Import  DatasetSourceType = "import"
+	Parquet DatasetSourceType = "parquet"
+	Tracker DatasetSourceType = "tracker"
+)
+
 // Defines values for HealthResponseStatus.
 const (
 	Degraded HealthResponseStatus = "degraded"
@@ -139,6 +146,23 @@ type CreateModuleTypeRequestCategory string
 type CreateModuleTypeSchemaRequest struct {
 	JsonSchema string `json:"json_schema"`
 }
+
+// Dataset defines model for Dataset.
+type Dataset struct {
+	CreatedAt     *time.Time        `json:"created_at,omitempty"`
+	Id            string            `json:"id"`
+	LastUpdatedAt *time.Time        `json:"last_updated_at,omitempty"`
+	Name          string            `json:"name"`
+	RowCount      *int64            `json:"row_count,omitempty"`
+	SchemaJson    *string           `json:"schema_json,omitempty"`
+	SourceType    DatasetSourceType `json:"source_type"`
+	StoragePath   string            `json:"storage_path"`
+	TenantId      string            `json:"tenant_id"`
+	UpdatedAt     *time.Time        `json:"updated_at,omitempty"`
+}
+
+// DatasetSourceType defines model for DatasetSourceType.
+type DatasetSourceType string
 
 // ErrorResponse defines model for ErrorResponse.
 type ErrorResponse struct {
@@ -349,6 +373,20 @@ type GetConnectionParams struct {
 
 // UpdateConnectionParams defines parameters for UpdateConnection.
 type UpdateConnectionParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// ListDatasetsParams defines parameters for ListDatasets.
+type ListDatasetsParams struct {
+	Q          *string            `form:"q,omitempty" json:"q,omitempty"`
+	SourceType *DatasetSourceType `form:"source_type,omitempty" json:"source_type,omitempty"`
+	Limit      *int               `form:"limit,omitempty" json:"limit,omitempty"`
+	Offset     *int               `form:"offset,omitempty" json:"offset,omitempty"`
+	XTenantID  XTenantID          `json:"X-Tenant-ID"`
+}
+
+// GetDatasetParams defines parameters for GetDataset.
+type GetDatasetParams struct {
 	XTenantID XTenantID `json:"X-Tenant-ID"`
 }
 

--- a/apps/golang/backend/usecase/dataset.go
+++ b/apps/golang/backend/usecase/dataset.go
@@ -1,0 +1,32 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/user/micro-dp/domain"
+)
+
+type DatasetService struct {
+	datasets domain.DatasetRepository
+}
+
+func NewDatasetService(datasets domain.DatasetRepository) *DatasetService {
+	return &DatasetService{datasets: datasets}
+}
+
+func (s *DatasetService) Get(ctx context.Context, id string) (*domain.Dataset, error) {
+	tenantID, ok := domain.TenantIDFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("tenant id not found in context")
+	}
+	return s.datasets.FindByID(ctx, tenantID, id)
+}
+
+func (s *DatasetService) List(ctx context.Context, filter domain.DatasetListFilter) ([]domain.Dataset, error) {
+	tenantID, ok := domain.TenantIDFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("tenant id not found in context")
+	}
+	return s.datasets.ListByTenant(ctx, tenantID, filter)
+}

--- a/apps/golang/e2e-cli/internal/config/config.go
+++ b/apps/golang/e2e-cli/internal/config/config.go
@@ -27,7 +27,7 @@ func Load(args []string) (*Config, error) {
 	baseURL := fs.String("base-url", envOr("E2E_BASE_URL", "http://localhost:8080"), "API base URL")
 	token := fs.String("token", envOr("E2E_TOKEN", ""), "Bearer token for authenticated requests")
 	tenantID := fs.String("tenant-id", envOr("E2E_TENANT_ID", ""), "Tenant header value")
-	suitesRaw := fs.String("suites", envOr("E2E_SUITES", "health,auth,events,job_runs,tenant"), "Comma separated suite names")
+	suitesRaw := fs.String("suites", envOr("E2E_SUITES", "health,auth,datasets,events,job_runs,tenant"), "Comma separated suite names")
 	jsonOut := fs.String("json-out", envOr("E2E_JSON_OUT", "e2e-report.json"), "JSON report output path")
 	authEmail := fs.String("auth-email", envOr("E2E_AUTH_EMAIL", ""), "Email for auth suite (optional)")
 	authPassword := fs.String("auth-password", envOr("E2E_AUTH_PASSWORD", "Passw0rd!123"), "Password for auth suite")

--- a/apps/golang/e2e-cli/internal/suite/datasets/happy_path/scenario.go
+++ b/apps/golang/e2e-cli/internal/suite/datasets/happy_path/scenario.go
@@ -1,0 +1,108 @@
+package happy_path
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/user/micro-dp/e2e-cli/internal/httpclient"
+)
+
+type Scenario struct {
+	password    string
+	displayName string
+}
+
+func NewScenario(password, displayName string) *Scenario {
+	return &Scenario{
+		password:    password,
+		displayName: displayName,
+	}
+}
+
+func (s *Scenario) ID() string {
+	return "datasets/happy_path/list_and_get"
+}
+
+func (s *Scenario) Run(ctx context.Context, client *httpclient.Client) error {
+	// 1. Register
+	email := fmt.Sprintf("e2e_datasets_%d@example.com", time.Now().UnixNano())
+	registerReq := map[string]string{
+		"email":        email,
+		"password":     s.password,
+		"display_name": s.displayName,
+	}
+	var registerResp struct {
+		UserID   string `json:"user_id"`
+		TenantID string `json:"tenant_id"`
+	}
+	code, body, err := client.PostJSON(ctx, "/api/v1/auth/register", registerReq, &registerResp)
+	if err != nil {
+		return err
+	}
+	if code != 201 {
+		return fmt.Errorf("register: status=%d body=%s", code, string(body))
+	}
+
+	// 2. Login
+	loginReq := map[string]string{
+		"email":    email,
+		"password": s.password,
+	}
+	var loginResp struct {
+		Token string `json:"token"`
+	}
+	code, body, err = client.PostJSON(ctx, "/api/v1/auth/login", loginReq, &loginResp)
+	if err != nil {
+		return err
+	}
+	if code != 200 {
+		return fmt.Errorf("login: status=%d body=%s", code, string(body))
+	}
+	client.SetToken(loginResp.Token)
+	client.SetTenantID(registerResp.TenantID)
+
+	// 3. GET /api/v1/datasets → 200, empty items
+	var listResp struct {
+		Items []any `json:"items"`
+	}
+	code, body, err = client.GetJSON(ctx, "/api/v1/datasets", &listResp)
+	if err != nil {
+		return err
+	}
+	if code != 200 {
+		return fmt.Errorf("list datasets: status=%d body=%s", code, string(body))
+	}
+	if len(listResp.Items) != 0 {
+		return fmt.Errorf("list datasets: expected 0 items, got=%d", len(listResp.Items))
+	}
+
+	// 4. GET /api/v1/datasets/nonexistent → 404
+	code, body, err = client.GetJSON(ctx, "/api/v1/datasets/nonexistent", nil)
+	if err != nil {
+		return err
+	}
+	if code != 404 {
+		return fmt.Errorf("get nonexistent dataset: expected 404 got=%d body=%s", code, string(body))
+	}
+
+	// 5. GET /api/v1/datasets?source_type=tracker → 200
+	code, body, err = client.GetJSON(ctx, "/api/v1/datasets?source_type=tracker", &listResp)
+	if err != nil {
+		return err
+	}
+	if code != 200 {
+		return fmt.Errorf("list datasets by source_type: status=%d body=%s", code, string(body))
+	}
+
+	// 6. GET /api/v1/datasets?q=test → 200
+	code, body, err = client.GetJSON(ctx, "/api/v1/datasets?q=test", &listResp)
+	if err != nil {
+		return err
+	}
+	if code != 200 {
+		return fmt.Errorf("list datasets by query: status=%d body=%s", code, string(body))
+	}
+
+	return nil
+}

--- a/apps/golang/e2e-cli/internal/suite/suite.go
+++ b/apps/golang/e2e-cli/internal/suite/suite.go
@@ -7,6 +7,7 @@ import (
 	"github.com/user/micro-dp/e2e-cli/internal/runner"
 	authfailure "github.com/user/micro-dp/e2e-cli/internal/suite/auth/failure"
 	authcase "github.com/user/micro-dp/e2e-cli/internal/suite/auth/happy_path"
+	datasetscase "github.com/user/micro-dp/e2e-cli/internal/suite/datasets/happy_path"
 	eventscase "github.com/user/micro-dp/e2e-cli/internal/suite/events/happy_path"
 	healthcase "github.com/user/micro-dp/e2e-cli/internal/suite/health/healthz"
 	jobrunscase "github.com/user/micro-dp/e2e-cli/internal/suite/job_runs/happy_path"
@@ -27,6 +28,8 @@ func Build(cfg *config.Config) ([]runner.Scenario, error) {
 			)
 		case "job_runs":
 			scenarios = append(scenarios, jobrunscase.NewScenario("", cfg.AuthPassword, cfg.DisplayName))
+		case "datasets":
+			scenarios = append(scenarios, datasetscase.NewScenario(cfg.AuthPassword, cfg.DisplayName))
 		case "events":
 			scenarios = append(scenarios, eventscase.NewScenario(cfg.AuthPassword, cfg.DisplayName))
 		case "tenant":

--- a/apps/node/web/src/lib/api/generated.ts
+++ b/apps/node/web/src/lib/api/generated.ts
@@ -337,6 +337,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/datasets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List datasets */
+        get: operations["listDatasets"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/datasets/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get dataset */
+        get: operations["getDataset"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -549,6 +583,24 @@ export interface components {
             config_json?: string;
             secret_ref?: string;
         };
+        Dataset: {
+            id: string;
+            tenant_id: string;
+            name: string;
+            source_type: components["schemas"]["DatasetSourceType"];
+            schema_json?: string;
+            /** Format: int64 */
+            row_count?: number;
+            storage_path: string;
+            /** Format: date-time */
+            last_updated_at?: string;
+            /** Format: date-time */
+            created_at?: string;
+            /** Format: date-time */
+            updated_at?: string;
+        };
+        /** @enum {string} */
+        DatasetSourceType: "tracker" | "parquet" | "import";
     };
     responses: {
         /** @description Error response */
@@ -1347,6 +1399,62 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            401: components["responses"]["ErrorResponse"];
+            404: components["responses"]["ErrorResponse"];
+        };
+    };
+    listDatasets: {
+        parameters: {
+            query?: {
+                q?: string;
+                source_type?: components["schemas"]["DatasetSourceType"];
+                limit?: number;
+                offset?: number;
+            };
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of datasets */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        items: components["schemas"]["Dataset"][];
+                    };
+                };
+            };
+            401: components["responses"]["ErrorResponse"];
+        };
+    };
+    getDataset: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Dataset detail */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Dataset"];
+                };
             };
             401: components["responses"]["ErrorResponse"];
             404: components["responses"]["ErrorResponse"];

--- a/spec/openapi/v1.yaml
+++ b/spec/openapi/v1.yaml
@@ -15,6 +15,7 @@ tags:
   - name: job_runs
   - name: module_types
   - name: connections
+  - name: datasets
 paths:
   /healthz:
     get:
@@ -794,6 +795,80 @@ paths:
         "404":
           $ref: "#/components/responses/ErrorResponse"
 
+  # ---- Datasets ----
+  /api/v1/datasets:
+    get:
+      tags: [datasets]
+      summary: List datasets
+      operationId: listDatasets
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: source_type
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/DatasetSourceType"
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        "200":
+          description: List of datasets
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Dataset"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+  /api/v1/datasets/{id}:
+    get:
+      tags: [datasets]
+      summary: Get dataset
+      operationId: getDataset
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Dataset detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Dataset"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+
 components:
   parameters:
     XTenantID:
@@ -1229,3 +1304,36 @@ components:
           type: string
         secret_ref:
           type: string
+
+    # ---- Dataset schemas ----
+    Dataset:
+      type: object
+      required: [id, tenant_id, name, source_type, storage_path]
+      properties:
+        id:
+          type: string
+        tenant_id:
+          type: string
+        name:
+          type: string
+        source_type:
+          $ref: "#/components/schemas/DatasetSourceType"
+        schema_json:
+          type: string
+        row_count:
+          type: integer
+          format: int64
+        storage_path:
+          type: string
+        last_updated_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    DatasetSourceType:
+      type: string
+      enum: [tracker, parquet, import]


### PR DESCRIPTION
## Summary

- Add read-only tenant-scoped Catalog API (`GET /api/v1/datasets`, `GET /api/v1/datasets/{id}`)
- Migration `000007_create_datasets` creates `datasets` table with tenant isolation and source_type indexing
- Full contract-first implementation: OpenAPI spec → codegen → domain → repo → usecase → handler → routes → E2E tests
- List endpoint supports `q` (name search), `source_type` filter, `limit`/`offset` pagination

## Test plan

- [ ] `make openapi-lint` passes
- [ ] `make openapi-generate` produces consistent output
- [ ] `cd apps/golang/backend && CGO_ENABLED=1 go build ./...` succeeds
- [ ] `cd apps/golang/e2e-cli && go build ./...` succeeds
- [ ] `make down && make up && make health` — services start, migration applied
- [ ] `GET /api/v1/datasets` → 200 `{"items":[]}`
- [ ] `GET /api/v1/datasets/nonexistent` → 404
- [ ] `make e2e-cli` — all suites pass including new `datasets` suite

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)