### PR TITLE
feat: tracker SDK integration + event summary dashboard

### DIFF
--- a/apps/docker/docker-compose.override.yaml
+++ b/apps/docker/docker-compose.override.yaml
@@ -25,5 +25,6 @@ services:
       dockerfile: apps/docker/web/Dockerfile.dev
     volumes:
       - ../../apps/node/web:/app
+      - ../../apps/node/sdk-tracker:/sdk-tracker
       - /app/node_modules
       - /app/.next

--- a/apps/docker/docker-compose.yaml
+++ b/apps/docker/docker-compose.yaml
@@ -129,6 +129,8 @@ services:
       - "${WEB_HOST_PORT:-3000}:3000"
     environment:
       API_BACKEND_URL: http://api:8080
+      NEXT_PUBLIC_TRACKER_ENABLED: ${TRACKER_ENABLED:-true}
+      NEXT_PUBLIC_TRACKER_DEBUG: ${TRACKER_DEBUG:-false}
     depends_on:
       api:
         condition: service_healthy

--- a/apps/docker/web/Dockerfile
+++ b/apps/docker/web/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:20-alpine AS builder
 
-WORKDIR /app
+WORKDIR /build
+COPY apps/node/sdk-tracker ./sdk-tracker
+
+WORKDIR /build/web
 COPY apps/node/web/package.json apps/node/web/package-lock.json* ./
 RUN npm ci
 
@@ -11,9 +14,9 @@ FROM node:20-alpine
 WORKDIR /app
 RUN apk add --no-cache wget
 
-COPY --from=builder /app/.next/standalone ./
-COPY --from=builder /app/.next/static ./.next/static
-COPY --from=builder /app/public ./public
+COPY --from=builder /build/web/.next/standalone ./
+COPY --from=builder /build/web/.next/static ./.next/static
+COPY --from=builder /build/web/public ./public
 
 ENV HOSTNAME=0.0.0.0
 EXPOSE 3000

--- a/apps/docker/web/Dockerfile.dev
+++ b/apps/docker/web/Dockerfile.dev
@@ -1,5 +1,7 @@
 FROM node:20-alpine
 
+COPY apps/node/sdk-tracker /sdk-tracker
+
 WORKDIR /app
 COPY apps/node/web/package.json apps/node/web/package-lock.json* ./
 RUN npm install

--- a/apps/golang/backend/cmd/api/main.go
+++ b/apps/golang/backend/cmd/api/main.go
@@ -122,6 +122,7 @@ func main() {
 
 	// Events
 	mux.Handle("POST /api/v1/events", protected(eventH.Ingest))
+	mux.Handle("GET /api/v1/events/summary", protected(eventH.Summary))
 
 	// Job runs
 	mux.Handle("POST /api/v1/job_runs", protected(jobRunH.Create))

--- a/apps/golang/backend/domain/event.go
+++ b/apps/golang/backend/domain/event.go
@@ -23,4 +23,6 @@ type EventQueue interface {
 	Enqueue(ctx context.Context, msg *EventQueueMessage) error
 	Dequeue(ctx context.Context) (*EventQueueMessage, error)
 	EnqueueDLQ(ctx context.Context, msg *EventQueueMessage, reason string) error
+	IncrementCount(ctx context.Context, tenantID, eventName string) error
+	GetCounts(ctx context.Context, tenantID string) (map[string]int64, error)
 }

--- a/apps/golang/backend/internal/openapi/server.gen.go
+++ b/apps/golang/backend/internal/openapi/server.gen.go
@@ -53,6 +53,9 @@ type ServerInterface interface {
 	// Ingest event
 	// (POST /api/v1/events)
 	IngestEvent(w http.ResponseWriter, r *http.Request, params IngestEventParams)
+	// Event counts summary
+	// (GET /api/v1/events/summary)
+	GetEventsSummary(w http.ResponseWriter, r *http.Request, params GetEventsSummaryParams)
 	// List job runs
 	// (GET /api/v1/job_runs)
 	ListJobRuns(w http.ResponseWriter, r *http.Request, params ListJobRunsParams)
@@ -552,6 +555,56 @@ func (siw *ServerInterfaceWrapper) IngestEvent(w http.ResponseWriter, r *http.Re
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.IngestEvent(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetEventsSummary operation middleware
+func (siw *ServerInterfaceWrapper) GetEventsSummary(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetEventsSummaryParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetEventsSummary(w, r, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1623,6 +1676,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/connections/{id}", wrapper.GetConnection)
 	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/connections/{id}", wrapper.UpdateConnection)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/events", wrapper.IngestEvent)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/events/summary", wrapper.GetEventsSummary)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/job_runs", wrapper.ListJobRuns)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/job_runs", wrapper.CreateJobRun)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/job_runs/{id}", wrapper.GetJobRun)
@@ -2115,6 +2169,32 @@ type IngestEvent409JSONResponse ErrorResponse
 func (response IngestEvent409JSONResponse) VisitIngestEventResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetEventsSummaryRequestObject struct {
+	Params GetEventsSummaryParams
+}
+
+type GetEventsSummaryResponseObject interface {
+	VisitGetEventsSummaryResponse(w http.ResponseWriter) error
+}
+
+type GetEventsSummary200JSONResponse EventsSummaryResponse
+
+func (response GetEventsSummary200JSONResponse) VisitGetEventsSummaryResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetEventsSummary401JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response GetEventsSummary401JSONResponse) VisitGetEventsSummaryResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -2770,6 +2850,9 @@ type StrictServerInterface interface {
 	// Ingest event
 	// (POST /api/v1/events)
 	IngestEvent(ctx context.Context, request IngestEventRequestObject) (IngestEventResponseObject, error)
+	// Event counts summary
+	// (GET /api/v1/events/summary)
+	GetEventsSummary(ctx context.Context, request GetEventsSummaryRequestObject) (GetEventsSummaryResponseObject, error)
 	// List job runs
 	// (GET /api/v1/job_runs)
 	ListJobRuns(ctx context.Context, request ListJobRunsRequestObject) (ListJobRunsResponseObject, error)
@@ -3199,6 +3282,32 @@ func (sh *strictHandler) IngestEvent(w http.ResponseWriter, r *http.Request, par
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(IngestEventResponseObject); ok {
 		if err := validResponse.VisitIngestEventResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetEventsSummary operation middleware
+func (sh *strictHandler) GetEventsSummary(w http.ResponseWriter, r *http.Request, params GetEventsSummaryParams) {
+	var request GetEventsSummaryRequestObject
+
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetEventsSummary(ctx, request.(GetEventsSummaryRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetEventsSummary")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetEventsSummaryResponseObject); ok {
+		if err := validResponse.VisitGetEventsSummaryResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {

--- a/apps/golang/backend/internal/openapi/types.gen.go
+++ b/apps/golang/backend/internal/openapi/types.gen.go
@@ -145,6 +145,18 @@ type ErrorResponse struct {
 	Error string `json:"error"`
 }
 
+// EventCount defines model for EventCount.
+type EventCount struct {
+	Count     int64  `json:"count"`
+	EventName string `json:"event_name"`
+}
+
+// EventsSummaryResponse defines model for EventsSummaryResponse.
+type EventsSummaryResponse struct {
+	Counts []EventCount `json:"counts"`
+	Total  int64        `json:"total"`
+}
+
 // HealthResponse defines model for HealthResponse.
 type HealthResponse struct {
 	Db     *string              `json:"db,omitempty"`
@@ -354,6 +366,11 @@ type UpdateConnectionParams struct {
 
 // IngestEventParams defines parameters for IngestEvent.
 type IngestEventParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// GetEventsSummaryParams defines parameters for GetEventsSummary.
+type GetEventsSummaryParams struct {
 	XTenantID XTenantID `json:"X-Tenant-ID"`
 }
 

--- a/apps/node/web/package-lock.json
+++ b/apps/node/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "micro-dp-web",
       "version": "0.1.0",
       "dependencies": {
+        "@micro-dp/sdk-tracker": "file:../sdk-tracker",
         "@radix-ui/react-label": "^2.1.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -28,6 +29,17 @@
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
         "typescript": "^5"
+      }
+    },
+    "../sdk-tracker": {
+      "name": "@micro-dp/sdk-tracker",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20.19.0",
+        "jsdom": "^28.1.0",
+        "tsup": "^8.5.0",
+        "typescript": "^5.9.2",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -539,6 +551,10 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@micro-dp/sdk-tracker": {
+      "resolved": "../sdk-tracker",
+      "link": true
     },
     "node_modules/@next/env": {
       "version": "15.1.0",

--- a/apps/node/web/package.json
+++ b/apps/node/web/package.json
@@ -19,7 +19,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "server-only": "^0.0.1",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "@micro-dp/sdk-tracker": "file:../sdk-tracker"
   },
   "devDependencies": {
     "@redocly/cli": "^2.1.0",

--- a/apps/node/web/src/app/api/events/route.ts
+++ b/apps/node/web/src/app/api/events/route.ts
@@ -1,0 +1,97 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+import { backendFetch } from "@/lib/api/server";
+import { TOKEN_COOKIE, TENANT_COOKIE } from "@/lib/auth/constants";
+
+const BATCH_LIMIT = 100;
+
+interface TrackerEvent {
+  event_id: string;
+  tenant_id?: string;
+  user_id?: string;
+  anonymous_id?: string;
+  session_id: string;
+  event_name: string;
+  properties: Record<string, unknown>;
+  event_time: string;
+  sent_at: string;
+}
+
+export async function POST(request: NextRequest) {
+  const jar = await cookies();
+  const token = jar.get(TOKEN_COOKIE)?.value;
+  const tenantId = jar.get(TENANT_COOKIE)?.value;
+
+  if (!token || !tenantId) {
+    return NextResponse.json({ error: "not authenticated" }, { status: 401 });
+  }
+
+  let body: { events?: TrackerEvent[] };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { error: "invalid request body" },
+      { status: 400 }
+    );
+  }
+
+  const events = body.events;
+  if (!Array.isArray(events) || events.length === 0) {
+    return NextResponse.json(
+      { error: "events array is required" },
+      { status: 400 }
+    );
+  }
+
+  if (events.length > BATCH_LIMIT) {
+    return NextResponse.json(
+      { error: `batch limit is ${BATCH_LIMIT} events` },
+      { status: 400 }
+    );
+  }
+
+  const results: { event_id: string; status: string; error?: string }[] = [];
+  let hasFailure = false;
+
+  for (const event of events) {
+    try {
+      const res = await backendFetch("/api/v1/events", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "X-Tenant-ID": tenantId,
+        },
+        body: JSON.stringify({
+          event_id: event.event_id,
+          event_name: event.event_name,
+          properties: event.properties,
+          event_time: event.event_time,
+        }),
+      });
+
+      if (res.ok) {
+        results.push({ event_id: event.event_id, status: "accepted" });
+      } else {
+        hasFailure = true;
+        const data = await res.json().catch(() => ({ error: "unknown" }));
+        results.push({
+          event_id: event.event_id,
+          status: "failed",
+          error: data.error,
+        });
+      }
+    } catch {
+      hasFailure = true;
+      results.push({
+        event_id: event.event_id,
+        status: "failed",
+        error: "internal error",
+      });
+    }
+  }
+
+  const status = hasFailure ? 207 : 202;
+  return NextResponse.json({ results }, { status });
+}

--- a/apps/node/web/src/app/api/events/summary/route.ts
+++ b/apps/node/web/src/app/api/events/summary/route.ts
@@ -1,0 +1,31 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { backendFetch } from "@/lib/api/server";
+import { TOKEN_COOKIE, TENANT_COOKIE } from "@/lib/auth/constants";
+import type { components } from "@/lib/api/generated";
+
+type ErrorResponse = components["schemas"]["ErrorResponse"];
+
+export async function GET() {
+  const jar = await cookies();
+  const token = jar.get(TOKEN_COOKIE)?.value;
+  const tenantId = jar.get(TENANT_COOKIE)?.value;
+
+  if (!token || !tenantId) {
+    return NextResponse.json(
+      { error: "not authenticated" } satisfies ErrorResponse,
+      { status: 401 }
+    );
+  }
+
+  const res = await backendFetch("/api/v1/events/summary", {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "X-Tenant-ID": tenantId,
+    },
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/node/web/src/app/dashboard/dashboard-header.tsx
+++ b/apps/node/web/src/app/dashboard/dashboard-header.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
+import { track, flush } from "@/components/tracker-provider";
 
 export function DashboardHeader({
   displayName,
@@ -14,6 +15,8 @@ export function DashboardHeader({
   const router = useRouter();
 
   async function handleSignOut() {
+    track("sign_out");
+    flush({ useBeacon: true });
     await fetch("/api/auth/logout", { method: "POST" });
     router.push("/signin");
     router.refresh();

--- a/apps/node/web/src/app/dashboard/event-summary.tsx
+++ b/apps/node/web/src/app/dashboard/event-summary.tsx
@@ -1,0 +1,60 @@
+import type { components } from "@/lib/api/generated";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+type EventsSummaryResponse = components["schemas"]["EventsSummaryResponse"];
+
+export function EventSummary({
+  summary,
+}: {
+  summary: EventsSummaryResponse | null;
+}) {
+  if (!summary || summary.total === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Events</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            No events tracked yet.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <h2 className="text-lg font-semibold tracking-tight">Events</h2>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Total
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-2xl font-bold">{summary.total}</p>
+          </CardContent>
+        </Card>
+        {summary.counts.map((item) => (
+          <Card key={item.event_name}>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium text-muted-foreground">
+                {item.event_name}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold">{item.count}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/node/web/src/app/dashboard/layout.tsx
+++ b/apps/node/web/src/app/dashboard/layout.tsx
@@ -5,6 +5,7 @@ import { backendFetch } from "@/lib/api/server";
 import { TOKEN_COOKIE } from "@/lib/auth/constants";
 import type { components } from "@/lib/api/generated";
 import { DashboardHeader } from "./dashboard-header";
+import { TrackerProvider } from "@/components/tracker-provider";
 
 type MeResponse = components["schemas"]["MeResponse"];
 
@@ -29,6 +30,7 @@ export default async function DashboardLayout({
   }
 
   const me: MeResponse = await res.json();
+  const tenantId = me.tenants.length > 0 ? me.tenants[0].id : "";
 
   return (
     <div className="min-h-screen">
@@ -36,7 +38,9 @@ export default async function DashboardLayout({
         displayName={me.display_name}
         email={me.email}
       />
-      <main className="container py-8">{children}</main>
+      <TrackerProvider tenantId={tenantId} userId={me.user_id}>
+        <main className="container py-8">{children}</main>
+      </TrackerProvider>
     </div>
   );
 }

--- a/apps/node/web/src/app/signin/signin-form.tsx
+++ b/apps/node/web/src/app/signin/signin-form.tsx
@@ -44,7 +44,8 @@ export function SigninForm() {
         return;
       }
 
-      router.push(callbackUrl);
+      const separator = callbackUrl.includes("?") ? "&" : "?";
+      router.push(`${callbackUrl}${separator}event=login_success`);
       router.refresh();
     } catch {
       setError("Network error");

--- a/apps/node/web/src/components/tracker-provider.tsx
+++ b/apps/node/web/src/components/tracker-provider.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { init, identify, page, track, flush } from "@micro-dp/sdk-tracker";
+
+const TRACKER_ENABLED =
+  process.env.NEXT_PUBLIC_TRACKER_ENABLED !== "false";
+const TRACKER_DEBUG =
+  process.env.NEXT_PUBLIC_TRACKER_DEBUG === "true";
+const TRACKER_ENDPOINT =
+  process.env.NEXT_PUBLIC_TRACKER_ENDPOINT ?? "/api/events";
+
+export function TrackerProvider({
+  tenantId,
+  userId,
+  children,
+}: {
+  tenantId: string;
+  userId: string;
+  children: React.ReactNode;
+}) {
+  const initialized = useRef(false);
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const prevPathname = useRef<string | null>(null);
+
+  // Initialize tracker once
+  useEffect(() => {
+    if (initialized.current) return;
+    initialized.current = true;
+
+    init({
+      endpoint: TRACKER_ENDPOINT,
+      tenantId,
+      userId,
+      enabled: TRACKER_ENABLED,
+      debug: TRACKER_DEBUG,
+    });
+
+    identify(userId);
+  }, [tenantId, userId]);
+
+  // Track page views on pathname change
+  useEffect(() => {
+    if (!initialized.current) return;
+    if (prevPathname.current === pathname) return;
+    prevPathname.current = pathname;
+
+    page("page_view", { path: pathname });
+  }, [pathname]);
+
+  // Detect login_success query param
+  useEffect(() => {
+    if (!initialized.current) return;
+    const event = searchParams.get("event");
+    if (event === "login_success") {
+      track("login_success");
+    }
+  }, [searchParams]);
+
+  return <>{children}</>;
+}
+
+export { track, flush };

--- a/apps/node/web/src/lib/api/generated.ts
+++ b/apps/node/web/src/lib/api/generated.ts
@@ -89,6 +89,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/events/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Event counts summary */
+        get: operations["getEventsSummary"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/admin/tenants": {
         parameters: {
             query?: never;
@@ -402,6 +419,16 @@ export interface components {
             /** @enum {string} */
             status: "accepted";
         };
+        EventsSummaryResponse: {
+            counts: components["schemas"]["EventCount"][];
+            /** Format: int64 */
+            total: number;
+        };
+        EventCount: {
+            event_name: string;
+            /** Format: int64 */
+            count: number;
+        };
         Job: {
             id: string;
             tenant_id: string;
@@ -690,6 +717,29 @@ export interface operations {
             400: components["responses"]["ErrorResponse"];
             401: components["responses"]["ErrorResponse"];
             409: components["responses"]["ErrorResponse"];
+        };
+    };
+    getEventsSummary: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Event counts summary */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventsSummaryResponse"];
+                };
+            };
+            401: components["responses"]["ErrorResponse"];
         };
     };
     adminListTenants: {

--- a/spec/openapi/v1.yaml
+++ b/spec/openapi/v1.yaml
@@ -119,6 +119,25 @@ paths:
         "409":
           $ref: "#/components/responses/ErrorResponse"
 
+  /api/v1/events/summary:
+    get:
+      tags: [events]
+      summary: Event counts summary
+      operationId: getEventsSummary
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+      responses:
+        "200":
+          description: Event counts summary
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventsSummaryResponse"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+
   # ---- Admin Tenants ----
   /api/v1/admin/tenants:
     post:
@@ -931,6 +950,28 @@ components:
         status:
           type: string
           enum: [accepted]
+
+    # ---- Event summary schemas ----
+    EventsSummaryResponse:
+      type: object
+      required: [counts, total]
+      properties:
+        counts:
+          type: array
+          items:
+            $ref: "#/components/schemas/EventCount"
+        total:
+          type: integer
+          format: int64
+    EventCount:
+      type: object
+      required: [event_name, count]
+      properties:
+        event_name:
+          type: string
+        count:
+          type: integer
+          format: int64
 
     # ---- Job schemas ----
     Job:


### PR DESCRIPTION
## Summary
- Integrate `@micro-dp/sdk-tracker` into the Next.js frontend with a BFF proxy pattern (`POST /api/events`) that splits SDK batch events into individual Go API calls, injecting auth token and tenant ID from httpOnly cookies
- Add Valkey-backed event counter (`HINCRBY`/`HGETALL`) with `GET /api/v1/events/summary` endpoint (OpenAPI contract-first)
- Add `TrackerProvider` client component that auto-tracks `page_view`, `login_success`, and `sign_out` events
- Display event counts summary cards on the dashboard page

## Changes
### New files (4)
- `apps/node/web/src/app/api/events/route.ts` — batch event proxy (splits SDK batch, forwards individually with auth)
- `apps/node/web/src/app/api/events/summary/route.ts` — summary API proxy
- `apps/node/web/src/components/tracker-provider.tsx` — TrackerProvider (init, identify, page_view, login_success detection)
- `apps/node/web/src/app/dashboard/event-summary.tsx` — event counts card grid

### Backend (6 files)
- `spec/openapi/v1.yaml` — `GET /api/v1/events/summary` + `EventsSummaryResponse` / `EventCount` schemas
- `domain/event.go` — `IncrementCount` / `GetCounts` added to `EventQueue` interface
- `queue/event_queue.go` — Valkey HASH implementation (`micro-dp:events:count:{tenant_id}`)
- `usecase/event.go` — best-effort counter increment on ingest + `Summary()` method
- `handler/event.go` — `Summary` handler
- `cmd/api/main.go` — route registration

### Frontend (4 files modified)
- `package.json` — `@micro-dp/sdk-tracker` file dependency
- `dashboard/layout.tsx` — wrap children in TrackerProvider
- `dashboard/page.tsx` — add EventSummary + parallel fetch
- `dashboard-header.tsx` — `sign_out` tracking with beacon
- `signin-form.tsx` — `?event=login_success` query param on redirect

### Docker (4 files)
- `Dockerfile` / `Dockerfile.dev` — COPY sdk-tracker for build
- `docker-compose.yaml` — `NEXT_PUBLIC_TRACKER_ENABLED`, `NEXT_PUBLIC_TRACKER_DEBUG`
- `docker-compose.override.yaml` — sdk-tracker volume mount for dev

## Test plan
- [x] `CGO_ENABLED=1 go build ./...` — backend compiles
- [x] `npx tsc --noEmit` — frontend type-checks
- [x] E2E CLI tests pass (6/6)
- [x] `POST /api/v1/events` returns 202 for individual events
- [x] `GET /api/v1/events/summary` returns correct counts from Valkey
- [x] `POST /api/events` (Next.js proxy) splits batch and returns 202
- [x] Browser: TrackerProvider fires `identify` + `page_view` on load
- [x] Browser: `?event=login_success` detected and tracked after login
- [x] Browser: `sign_out` tracked via beacon before logout
- [x] Browser: Dashboard shows event summary cards with counts

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)