### PR TITLE
feat(web): connections/admin tenants management pages

### DIFF
--- a/apps/node/web/src/app/admin/tenants/page.tsx
+++ b/apps/node/web/src/app/admin/tenants/page.tsx
@@ -1,0 +1,70 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { DashboardHeader } from "@/app/dashboard/dashboard-header";
+import type { components } from "@/lib/api/generated";
+import { backendFetch } from "@/lib/api/server";
+import { TOKEN_COOKIE } from "@/lib/auth/constants";
+import { TenantsManager } from "./tenants-manager";
+
+type MeResponse = components["schemas"]["MeResponse"];
+type Tenant = components["schemas"]["Tenant"];
+
+export default async function AdminTenantsPage() {
+  const jar = await cookies();
+  const token = jar.get(TOKEN_COOKIE)?.value;
+  if (!token) {
+    redirect("/signin");
+  }
+
+  const meRes = await backendFetch("/api/v1/auth/me", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!meRes.ok) {
+    redirect("/signin");
+  }
+  const me: MeResponse = await meRes.json();
+
+  if (me.platform_role !== "superadmin") {
+    return (
+      <div className="min-h-screen">
+        <DashboardHeader
+          displayName={me.display_name}
+          email={me.email}
+          platformRole={me.platform_role}
+        />
+        <main className="container py-8">
+          <div className="rounded-lg border p-6">
+            <h1 className="text-2xl font-semibold tracking-tight">403 Forbidden</h1>
+            <p className="mt-2 text-muted-foreground">
+              This page is available only for superadmin users.
+            </p>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
+  let initialTenants: Tenant[] = [];
+  const tenantsRes = await backendFetch("/api/v1/admin/tenants", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (tenantsRes.ok) {
+    const data: { items: Tenant[] } = await tenantsRes.json();
+    initialTenants = data.items ?? [];
+  }
+
+  return (
+    <div className="min-h-screen">
+      <DashboardHeader
+        displayName={me.display_name}
+        email={me.email}
+        platformRole={me.platform_role}
+      />
+      <main className="container space-y-6 py-8">
+        <h1 className="text-2xl font-semibold tracking-tight">Admin Tenants</h1>
+        <TenantsManager initialTenants={initialTenants} />
+      </main>
+    </div>
+  );
+}

--- a/apps/node/web/src/app/admin/tenants/tenants-manager.tsx
+++ b/apps/node/web/src/app/admin/tenants/tenants-manager.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { components } from "@/lib/api/generated";
+
+type Tenant = components["schemas"]["Tenant"];
+
+export function TenantsManager({ initialTenants }: { initialTenants: Tenant[] }) {
+  const [tenants, setTenants] = useState(initialTenants);
+  const [newName, setNewName] = useState("");
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function refreshTenants() {
+    const res = await fetch("/api/admin/tenants", { cache: "no-store" });
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(err.error ?? "failed to load tenants");
+    }
+    const data = (await res.json()) as { items: Tenant[] };
+    setTenants(data.items ?? []);
+  }
+
+  async function handleCreate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoading(true);
+    setMessage("");
+    try {
+      const res = await fetch("/api/admin/tenants", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: newName }),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error ?? "create failed");
+      }
+      setNewName("");
+      await refreshTenants();
+      setMessage("Tenant created.");
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : "request failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function toggleActive(tenant: Tenant) {
+    setLoading(true);
+    setMessage("");
+    try {
+      const res = await fetch(`/api/admin/tenants/${tenant.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ is_active: !tenant.is_active }),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error ?? "update failed");
+      }
+      await refreshTenants();
+      setMessage("Tenant updated.");
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : "request failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      <form onSubmit={handleCreate} className="space-y-4 rounded-lg border p-4">
+        <h2 className="text-lg font-semibold">Create Tenant</h2>
+        <div className="space-y-2">
+          <Label htmlFor="tenant_name">Tenant Name</Label>
+          <Input
+            id="tenant_name"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            required
+          />
+        </div>
+        <Button type="submit" disabled={loading}>
+          Create
+        </Button>
+        {message ? <p className="text-sm text-muted-foreground">{message}</p> : null}
+      </form>
+
+      <div className="rounded-lg border">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b bg-muted/50">
+              <th className="px-4 py-3 text-left font-medium">ID</th>
+              <th className="px-4 py-3 text-left font-medium">Name</th>
+              <th className="px-4 py-3 text-left font-medium">Status</th>
+              <th className="px-4 py-3 text-left font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tenants.map((tenant) => (
+              <tr key={tenant.id} className="border-b last:border-0">
+                <td className="px-4 py-3 font-mono text-xs">{tenant.id.slice(0, 8)}</td>
+                <td className="px-4 py-3">{tenant.name}</td>
+                <td className="px-4 py-3">
+                  {tenant.is_active ? (
+                    <span className="text-green-700">active</span>
+                  ) : (
+                    <span className="text-red-700">inactive</span>
+                  )}
+                </td>
+                <td className="px-4 py-3">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={loading}
+                    onClick={() => toggleActive(tenant)}
+                  >
+                    {tenant.is_active ? "Deactivate" : "Activate"}
+                  </Button>
+                </td>
+              </tr>
+            ))}
+            {tenants.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-4 py-6 text-center text-muted-foreground">
+                  No tenants yet.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/node/web/src/app/api/admin/tenants/[id]/route.ts
+++ b/apps/node/web/src/app/api/admin/tenants/[id]/route.ts
@@ -1,0 +1,54 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+import type { components } from "@/lib/api/generated";
+import { backendFetch } from "@/lib/api/server";
+import { TOKEN_COOKIE } from "@/lib/auth/constants";
+
+type ErrorResponse = components["schemas"]["ErrorResponse"];
+type MeResponse = components["schemas"]["MeResponse"];
+
+type AdminAuthResult =
+  | { headers: { Authorization: string } }
+  | { error: ErrorResponse; status: 401 | 403 };
+
+async function adminAuthHeader(): Promise<AdminAuthResult> {
+  const jar = await cookies();
+  const token = jar.get(TOKEN_COOKIE)?.value;
+  if (!token) {
+    return { error: { error: "not authenticated" }, status: 401 };
+  }
+
+  const meRes = await backendFetch("/api/v1/auth/me", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!meRes.ok) {
+    return { error: { error: "not authenticated" }, status: 401 };
+  }
+  const me: MeResponse = await meRes.json();
+  if (me.platform_role !== "superadmin") {
+    return { error: { error: "forbidden" }, status: 403 };
+  }
+
+  return { headers: { Authorization: `Bearer ${token}` } };
+}
+
+export async function PATCH(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const auth = await adminAuthHeader();
+  if ("error" in auth) {
+    return NextResponse.json(auth.error, { status: auth.status });
+  }
+
+  const { id } = await context.params;
+  const body = await request.json();
+  const res = await backendFetch(`/api/v1/admin/tenants/${id}`, {
+    method: "PATCH",
+    headers: auth.headers,
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/node/web/src/app/api/admin/tenants/route.ts
+++ b/apps/node/web/src/app/api/admin/tenants/route.ts
@@ -1,0 +1,63 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+import type { components } from "@/lib/api/generated";
+import { backendFetch } from "@/lib/api/server";
+import { TOKEN_COOKIE } from "@/lib/auth/constants";
+
+type ErrorResponse = components["schemas"]["ErrorResponse"];
+type MeResponse = components["schemas"]["MeResponse"];
+
+type AdminAuthResult =
+  | { headers: { Authorization: string } }
+  | { error: ErrorResponse; status: 401 | 403 };
+
+async function adminAuthHeader(): Promise<AdminAuthResult> {
+  const jar = await cookies();
+  const token = jar.get(TOKEN_COOKIE)?.value;
+  if (!token) {
+    return { error: { error: "not authenticated" }, status: 401 };
+  }
+
+  const meRes = await backendFetch("/api/v1/auth/me", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!meRes.ok) {
+    return { error: { error: "not authenticated" }, status: 401 };
+  }
+  const me: MeResponse = await meRes.json();
+  if (me.platform_role !== "superadmin") {
+    return { error: { error: "forbidden" }, status: 403 };
+  }
+
+  return { headers: { Authorization: `Bearer ${token}` } };
+}
+
+export async function GET() {
+  const auth = await adminAuthHeader();
+  if ("error" in auth) {
+    return NextResponse.json(auth.error, { status: auth.status });
+  }
+
+  const res = await backendFetch("/api/v1/admin/tenants", {
+    headers: auth.headers,
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}
+
+export async function POST(request: NextRequest) {
+  const auth = await adminAuthHeader();
+  if ("error" in auth) {
+    return NextResponse.json(auth.error, { status: auth.status });
+  }
+
+  const body = await request.json();
+  const res = await backendFetch("/api/v1/admin/tenants", {
+    method: "POST",
+    headers: auth.headers,
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/node/web/src/app/api/connections/[id]/route.ts
+++ b/apps/node/web/src/app/api/connections/[id]/route.ts
@@ -1,0 +1,86 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+import type { components } from "@/lib/api/generated";
+import { backendFetch } from "@/lib/api/server";
+import { TENANT_COOKIE, TOKEN_COOKIE } from "@/lib/auth/constants";
+
+type ErrorResponse = components["schemas"]["ErrorResponse"];
+
+async function authHeaders() {
+  const jar = await cookies();
+  const token = jar.get(TOKEN_COOKIE)?.value;
+  const tenantId = jar.get(TENANT_COOKIE)?.value;
+  if (!token || !tenantId) {
+    return null;
+  }
+  return {
+    Authorization: `Bearer ${token}`,
+    "X-Tenant-ID": tenantId,
+  };
+}
+
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const headers = await authHeaders();
+  if (!headers) {
+    return NextResponse.json(
+      { error: "not authenticated" } satisfies ErrorResponse,
+      { status: 401 }
+    );
+  }
+
+  const { id } = await context.params;
+  const res = await backendFetch(`/api/v1/connections/${id}`, { headers });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}
+
+export async function PUT(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const headers = await authHeaders();
+  if (!headers) {
+    return NextResponse.json(
+      { error: "not authenticated" } satisfies ErrorResponse,
+      { status: 401 }
+    );
+  }
+
+  const { id } = await context.params;
+  const body = await request.json();
+  const res = await backendFetch(`/api/v1/connections/${id}`, {
+    method: "PUT",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const headers = await authHeaders();
+  if (!headers) {
+    return NextResponse.json(
+      { error: "not authenticated" } satisfies ErrorResponse,
+      { status: 401 }
+    );
+  }
+
+  const { id } = await context.params;
+  const res = await backendFetch(`/api/v1/connections/${id}`, {
+    method: "DELETE",
+    headers,
+  });
+  if (res.status === 204) {
+    return new NextResponse(null, { status: 204 });
+  }
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/node/web/src/app/api/connections/route.ts
+++ b/apps/node/web/src/app/api/connections/route.ts
@@ -1,0 +1,54 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+import type { components } from "@/lib/api/generated";
+import { backendFetch } from "@/lib/api/server";
+import { TENANT_COOKIE, TOKEN_COOKIE } from "@/lib/auth/constants";
+
+type ErrorResponse = components["schemas"]["ErrorResponse"];
+
+async function authHeaders() {
+  const jar = await cookies();
+  const token = jar.get(TOKEN_COOKIE)?.value;
+  const tenantId = jar.get(TENANT_COOKIE)?.value;
+  if (!token || !tenantId) {
+    return null;
+  }
+  return {
+    Authorization: `Bearer ${token}`,
+    "X-Tenant-ID": tenantId,
+  };
+}
+
+export async function GET() {
+  const headers = await authHeaders();
+  if (!headers) {
+    return NextResponse.json(
+      { error: "not authenticated" } satisfies ErrorResponse,
+      { status: 401 }
+    );
+  }
+
+  const res = await backendFetch("/api/v1/connections", { headers });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}
+
+export async function POST(request: NextRequest) {
+  const headers = await authHeaders();
+  if (!headers) {
+    return NextResponse.json(
+      { error: "not authenticated" } satisfies ErrorResponse,
+      { status: 401 }
+    );
+  }
+
+  const body = await request.json();
+  const res = await backendFetch("/api/v1/connections", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/node/web/src/app/connections/connections-manager.tsx
+++ b/apps/node/web/src/app/connections/connections-manager.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { components } from "@/lib/api/generated";
+
+type Connection = components["schemas"]["Connection"];
+
+type FormState = {
+  name: string;
+  type: string;
+  config_json: string;
+  secret_ref: string;
+};
+
+const emptyForm: FormState = {
+  name: "",
+  type: "",
+  config_json: "{}",
+  secret_ref: "",
+};
+
+export function ConnectionsManager({
+  initialConnections,
+}: {
+  initialConnections: Connection[];
+}) {
+  const [connections, setConnections] = useState(initialConnections);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [message, setMessage] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+
+  const isEditing = useMemo(() => editingId !== null, [editingId]);
+
+  async function refreshConnections() {
+    const res = await fetch("/api/connections", { cache: "no-store" });
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(err.error ?? "failed to load connections");
+    }
+    const data = (await res.json()) as { items: Connection[] };
+    setConnections(data.items ?? []);
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoading(true);
+    setMessage("");
+    try {
+      const payload = {
+        name: form.name,
+        type: form.type,
+        config_json: form.config_json || "{}",
+        secret_ref: form.secret_ref || undefined,
+      };
+
+      const res = await fetch(
+        isEditing ? `/api/connections/${editingId}` : "/api/connections",
+        {
+          method: isEditing ? "PUT" : "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        }
+      );
+
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error ?? "save failed");
+      }
+
+      await refreshConnections();
+      setForm(emptyForm);
+      setEditingId(null);
+      setMessage(isEditing ? "Connection updated." : "Connection created.");
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : "request failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function beginEdit(connection: Connection) {
+    setEditingId(connection.id);
+    setForm({
+      name: connection.name,
+      type: connection.type,
+      config_json: connection.config_json ?? "{}",
+      secret_ref: connection.secret_ref ?? "",
+    });
+    setMessage("");
+  }
+
+  async function handleDelete(id: string) {
+    setLoading(true);
+    setMessage("");
+    try {
+      const res = await fetch(`/api/connections/${id}`, { method: "DELETE" });
+      if (!res.ok && res.status !== 204) {
+        const err = await res.json();
+        throw new Error(err.error ?? "delete failed");
+      }
+      await refreshConnections();
+      if (editingId === id) {
+        setEditingId(null);
+        setForm(emptyForm);
+      }
+      setMessage("Connection deleted.");
+    } catch (e) {
+      setMessage(e instanceof Error ? e.message : "request failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border p-4">
+        <h2 className="text-lg font-semibold">
+          {isEditing ? "Edit Connection" : "Create Connection"}
+        </h2>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              value={form.name}
+              onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="type">Type</Label>
+            <Input
+              id="type"
+              value={form.type}
+              onChange={(e) => setForm((prev) => ({ ...prev, type: e.target.value }))}
+              required
+            />
+          </div>
+          <div className="space-y-2 md:col-span-2">
+            <Label htmlFor="config_json">Config JSON</Label>
+            <Input
+              id="config_json"
+              value={form.config_json}
+              onChange={(e) =>
+                setForm((prev) => ({ ...prev, config_json: e.target.value }))
+              }
+            />
+          </div>
+          <div className="space-y-2 md:col-span-2">
+            <Label htmlFor="secret_ref">Secret Ref</Label>
+            <Input
+              id="secret_ref"
+              value={form.secret_ref}
+              onChange={(e) =>
+                setForm((prev) => ({ ...prev, secret_ref: e.target.value }))
+              }
+            />
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button type="submit" disabled={loading}>
+            {isEditing ? "Update" : "Create"}
+          </Button>
+          {isEditing ? (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setEditingId(null);
+                setForm(emptyForm);
+              }}
+            >
+              Cancel
+            </Button>
+          ) : null}
+        </div>
+        {message ? <p className="text-sm text-muted-foreground">{message}</p> : null}
+      </form>
+
+      <div className="rounded-lg border">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b bg-muted/50">
+              <th className="px-4 py-3 text-left font-medium">Name</th>
+              <th className="px-4 py-3 text-left font-medium">Type</th>
+              <th className="px-4 py-3 text-left font-medium">Secret Ref</th>
+              <th className="px-4 py-3 text-left font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {connections.map((connection) => (
+              <tr key={connection.id} className="border-b last:border-0">
+                <td className="px-4 py-3">{connection.name}</td>
+                <td className="px-4 py-3">{connection.type}</td>
+                <td className="px-4 py-3 text-muted-foreground">
+                  {connection.secret_ref ?? "-"}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => beginEdit(connection)}
+                      disabled={loading}
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      onClick={() => handleDelete(connection.id)}
+                      disabled={loading}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+            {connections.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-4 py-6 text-center text-muted-foreground">
+                  No connections yet.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/node/web/src/app/connections/page.tsx
+++ b/apps/node/web/src/app/connections/page.tsx
@@ -1,0 +1,54 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { DashboardHeader } from "@/app/dashboard/dashboard-header";
+import type { components } from "@/lib/api/generated";
+import { backendFetch } from "@/lib/api/server";
+import { TENANT_COOKIE, TOKEN_COOKIE } from "@/lib/auth/constants";
+import { ConnectionsManager } from "./connections-manager";
+
+type MeResponse = components["schemas"]["MeResponse"];
+type Connection = components["schemas"]["Connection"];
+
+export default async function ConnectionsPage() {
+  const jar = await cookies();
+  const token = jar.get(TOKEN_COOKIE)?.value;
+  const tenantId = jar.get(TENANT_COOKIE)?.value;
+  if (!token || !tenantId) {
+    redirect("/signin");
+  }
+
+  const meRes = await backendFetch("/api/v1/auth/me", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!meRes.ok) {
+    redirect("/signin");
+  }
+  const me: MeResponse = await meRes.json();
+
+  let initialConnections: Connection[] = [];
+  const connectionsRes = await backendFetch("/api/v1/connections", {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "X-Tenant-ID": tenantId,
+    },
+  });
+  if (connectionsRes.ok) {
+    const data: { items: Connection[] } = await connectionsRes.json();
+    initialConnections = data.items ?? [];
+  }
+
+  return (
+    <div className="min-h-screen">
+      <DashboardHeader
+        displayName={me.display_name}
+        email={me.email}
+        platformRole={me.platform_role}
+      />
+      <main className="container space-y-6 py-8">
+        <h1 className="text-2xl font-semibold tracking-tight">Connections</h1>
+        <ConnectionsManager initialConnections={initialConnections} />
+      </main>
+    </div>
+  );
+}

--- a/apps/node/web/src/app/dashboard/dashboard-header.tsx
+++ b/apps/node/web/src/app/dashboard/dashboard-header.tsx
@@ -1,17 +1,29 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
 
 export function DashboardHeader({
   displayName,
   email,
+  platformRole,
 }: {
   displayName: string;
   email: string;
+  platformRole: "user" | "superadmin";
 }) {
   const router = useRouter();
+  const pathname = usePathname();
+
+  const navItems: Array<{ href: string; label: string }> = [
+    { href: "/dashboard", label: "Dashboard" },
+    { href: "/connections", label: "Connections" },
+  ];
+  if (platformRole === "superadmin") {
+    navItems.push({ href: "/admin/tenants", label: "Admin Tenants" });
+  }
 
   async function handleSignOut() {
     await fetch("/api/auth/logout", { method: "POST" });
@@ -21,8 +33,28 @@ export function DashboardHeader({
 
   return (
     <header className="border-b">
-      <div className="container flex h-14 items-center justify-between">
-        <span className="font-semibold">micro-dp</span>
+      <div className="container flex min-h-14 flex-wrap items-center justify-between gap-3 py-2">
+        <div className="flex items-center gap-6">
+          <span className="font-semibold">micro-dp</span>
+          <nav className="flex items-center gap-2 text-sm">
+            {navItems.map((item) => {
+              const active = pathname === item.href;
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={
+                    active
+                      ? "rounded-md bg-secondary px-2 py-1 font-medium"
+                      : "rounded-md px-2 py-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+                  }
+                >
+                  {item.label}
+                </Link>
+              );
+            })}
+          </nav>
+        </div>
         <div className="flex items-center gap-4">
           <span className="text-sm text-muted-foreground">
             {displayName || email}

--- a/apps/node/web/src/app/dashboard/layout.tsx
+++ b/apps/node/web/src/app/dashboard/layout.tsx
@@ -35,6 +35,7 @@ export default async function DashboardLayout({
       <DashboardHeader
         displayName={me.display_name}
         email={me.email}
+        platformRole={me.platform_role}
       />
       <main className="container py-8">{children}</main>
     </div>

--- a/apps/node/web/src/middleware.ts
+++ b/apps/node/web/src/middleware.ts
@@ -6,8 +6,13 @@ export function middleware(request: NextRequest) {
   const token = request.cookies.get(TOKEN_COOKIE)?.value;
   const { pathname } = request.nextUrl;
 
-  // Protect /dashboard routes
-  if (pathname.startsWith("/dashboard") && !token) {
+  // Protect authenticated routes
+  if (
+    (pathname.startsWith("/dashboard") ||
+      pathname.startsWith("/connections") ||
+      pathname.startsWith("/admin")) &&
+    !token
+  ) {
     const url = request.nextUrl.clone();
     url.pathname = "/signin";
     url.searchParams.set("callbackUrl", pathname);
@@ -26,5 +31,11 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/signin", "/signup"],
+  matcher: [
+    "/dashboard/:path*",
+    "/connections/:path*",
+    "/admin/:path*",
+    "/signin",
+    "/signup",
+  ],
 };


### PR DESCRIPTION
## Summary
- add `/connections` page with create/list/update/delete UI
- add superadmin-only `/admin/tenants` page with create and activation toggle UI
- add Next.js API routes for connections and admin tenants
- add role-based nav visibility and route protection updates

## Verification
- npm run build (apps/node/web)
- manual HTTP verification on `http://localhost:3900`
  - unauthenticated `/connections` redirects to signin
  - connections CRUD works for normal user
  - normal user gets `403` on `/api/admin/tenants`
  - superadmin can access `/admin/tenants` and create/update tenants

Closes #26