### PR TITLE
feat(web): add datasets list/detail pages

### DIFF
--- a/apps/node/web/src/app/api/datasets/[id]/route.ts
+++ b/apps/node/web/src/app/api/datasets/[id]/route.ts
@@ -1,0 +1,34 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+import type { components } from "@/lib/api/generated";
+import { backendFetch } from "@/lib/api/server";
+import { TENANT_COOKIE, TOKEN_COOKIE } from "@/lib/auth/constants";
+
+type ErrorResponse = components["schemas"]["ErrorResponse"];
+
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const jar = await cookies();
+  const token = jar.get(TOKEN_COOKIE)?.value;
+  const tenantId = jar.get(TENANT_COOKIE)?.value;
+  if (!token || !tenantId) {
+    return NextResponse.json(
+      { error: "not authenticated" } satisfies ErrorResponse,
+      { status: 401 }
+    );
+  }
+
+  const { id } = await context.params;
+  const res = await backendFetch(`/api/v1/datasets/${id}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "X-Tenant-ID": tenantId,
+    },
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/node/web/src/app/api/datasets/route.ts
+++ b/apps/node/web/src/app/api/datasets/route.ts
@@ -1,0 +1,31 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+import type { components } from "@/lib/api/generated";
+import { backendFetch } from "@/lib/api/server";
+import { TENANT_COOKIE, TOKEN_COOKIE } from "@/lib/auth/constants";
+
+type ErrorResponse = components["schemas"]["ErrorResponse"];
+
+export async function GET(request: NextRequest) {
+  const jar = await cookies();
+  const token = jar.get(TOKEN_COOKIE)?.value;
+  const tenantId = jar.get(TENANT_COOKIE)?.value;
+  if (!token || !tenantId) {
+    return NextResponse.json(
+      { error: "not authenticated" } satisfies ErrorResponse,
+      { status: 401 }
+    );
+  }
+
+  const query = request.nextUrl.search;
+  const res = await backendFetch(`/api/v1/datasets${query}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "X-Tenant-ID": tenantId,
+    },
+  });
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/node/web/src/app/dashboard/dashboard-header.tsx
+++ b/apps/node/web/src/app/dashboard/dashboard-header.tsx
@@ -20,6 +20,7 @@ export function DashboardHeader({
 
   const navItems: Array<{ href: string; label: string }> = [
     { href: "/dashboard", label: "Dashboard" },
+    { href: "/datasets", label: "Datasets" },
     { href: "/connections", label: "Connections" },
   ];
   if (platformRole === "superadmin") {

--- a/apps/node/web/src/app/datasets/[id]/page.tsx
+++ b/apps/node/web/src/app/datasets/[id]/page.tsx
@@ -1,0 +1,128 @@
+import Link from "next/link";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { DashboardHeader } from "@/app/dashboard/dashboard-header";
+import { backendFetch } from "@/lib/api/server";
+import { TENANT_COOKIE, TOKEN_COOKIE } from "@/lib/auth/constants";
+import type { components } from "@/lib/api/generated";
+
+type MeResponse = components["schemas"]["MeResponse"];
+type Dataset = components["schemas"]["Dataset"];
+
+function prettyJSON(input?: string): string {
+  if (!input) {
+    return "{}";
+  }
+  try {
+    return JSON.stringify(JSON.parse(input), null, 2);
+  } catch {
+    return input;
+  }
+}
+
+export default async function DatasetDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  const jar = await cookies();
+  const token = jar.get(TOKEN_COOKIE)?.value;
+  const tenantId = jar.get(TENANT_COOKIE)?.value;
+  if (!token || !tenantId) {
+    redirect("/signin");
+  }
+
+  const meRes = await backendFetch("/api/v1/auth/me", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!meRes.ok) {
+    redirect("/signin");
+  }
+  const me: MeResponse = await meRes.json();
+
+  const datasetRes = await backendFetch(`/api/v1/datasets/${id}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "X-Tenant-ID": tenantId,
+    },
+    cache: "no-store",
+  });
+
+  let dataset: Dataset | null = null;
+  let errorMessage = "";
+  if (datasetRes.ok) {
+    dataset = await datasetRes.json();
+  } else {
+    const err = (await datasetRes.json()) as { error?: string };
+    errorMessage = err.error ?? `failed to load dataset (${datasetRes.status})`;
+  }
+
+  return (
+    <div className="min-h-screen">
+      <DashboardHeader
+        displayName={me.display_name}
+        email={me.email}
+        platformRole={me.platform_role}
+      />
+      <main className="container space-y-6 py-8">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-semibold tracking-tight">Dataset Detail</h1>
+          <Link href="/datasets" className="text-sm underline-offset-2 hover:underline">
+            Back to list
+          </Link>
+        </div>
+
+        {errorMessage ? (
+          <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+            {errorMessage}
+          </div>
+        ) : null}
+
+        {dataset ? (
+          <div className="space-y-6">
+            <div className="grid gap-4 rounded-lg border p-4 md:grid-cols-2">
+              <div>
+                <p className="text-xs text-muted-foreground">ID</p>
+                <p className="font-mono text-sm">{dataset.id}</p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Name</p>
+                <p className="text-sm">{dataset.name}</p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Source Type</p>
+                <p className="text-sm">{dataset.source_type}</p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Row Count</p>
+                <p className="text-sm">{dataset.row_count ?? "-"}</p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Storage Path</p>
+                <p className="font-mono text-sm">{dataset.storage_path}</p>
+              </div>
+              <div>
+                <p className="text-xs text-muted-foreground">Last Updated</p>
+                <p className="text-sm">
+                  {dataset.last_updated_at
+                    ? new Date(dataset.last_updated_at).toLocaleString()
+                    : "-"}
+                </p>
+              </div>
+            </div>
+
+            <div className="rounded-lg border p-4">
+              <h2 className="mb-2 text-lg font-semibold">Schema JSON</h2>
+              <pre className="overflow-auto rounded bg-muted p-3 text-xs">
+                {prettyJSON(dataset.schema_json)}
+              </pre>
+            </div>
+          </div>
+        ) : null}
+      </main>
+    </div>
+  );
+}

--- a/apps/node/web/src/app/datasets/page.tsx
+++ b/apps/node/web/src/app/datasets/page.tsx
@@ -1,0 +1,214 @@
+import Link from "next/link";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { DashboardHeader } from "@/app/dashboard/dashboard-header";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { components } from "@/lib/api/generated";
+import { backendFetch } from "@/lib/api/server";
+import { TENANT_COOKIE, TOKEN_COOKIE } from "@/lib/auth/constants";
+
+type MeResponse = components["schemas"]["MeResponse"];
+type Dataset = components["schemas"]["Dataset"];
+type SourceType = components["schemas"]["DatasetSourceType"];
+
+const sourceTypes: SourceType[] = ["tracker", "parquet", "import"];
+
+function toPositiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+export default async function DatasetsPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+
+  const q = typeof params.q === "string" ? params.q : "";
+  const sourceType =
+    typeof params.source_type === "string" &&
+    sourceTypes.includes(params.source_type as SourceType)
+      ? (params.source_type as SourceType)
+      : "";
+  const page = toPositiveInt(
+    typeof params.page === "string" ? params.page : undefined,
+    1
+  );
+  const limit = Math.min(
+    50,
+    toPositiveInt(typeof params.limit === "string" ? params.limit : undefined, 10)
+  );
+  const offset = (page - 1) * limit;
+
+  const jar = await cookies();
+  const token = jar.get(TOKEN_COOKIE)?.value;
+  const tenantId = jar.get(TENANT_COOKIE)?.value;
+  if (!token || !tenantId) {
+    redirect("/signin");
+  }
+
+  const meRes = await backendFetch("/api/v1/auth/me", {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!meRes.ok) {
+    redirect("/signin");
+  }
+  const me: MeResponse = await meRes.json();
+
+  const query = new URLSearchParams();
+  if (q) query.set("q", q);
+  if (sourceType) query.set("source_type", sourceType);
+  query.set("limit", String(limit));
+  query.set("offset", String(offset));
+
+  const datasetsRes = await backendFetch(`/api/v1/datasets?${query.toString()}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "X-Tenant-ID": tenantId,
+    },
+    cache: "no-store",
+  });
+
+  let datasets: Dataset[] = [];
+  let errorMessage = "";
+
+  if (datasetsRes.ok) {
+    const data: { items: Dataset[] } = await datasetsRes.json();
+    datasets = data.items ?? [];
+  } else {
+    const err = (await datasetsRes.json()) as { error?: string };
+    errorMessage = err.error ?? `failed to load datasets (${datasetsRes.status})`;
+  }
+
+  const hasPrev = page > 1;
+  const hasNext = datasets.length === limit;
+
+  function buildPageHref(targetPage: number): string {
+    const p = new URLSearchParams();
+    if (q) p.set("q", q);
+    if (sourceType) p.set("source_type", sourceType);
+    p.set("limit", String(limit));
+    p.set("page", String(targetPage));
+    return `/datasets?${p.toString()}`;
+  }
+
+  return (
+    <div className="min-h-screen">
+      <DashboardHeader
+        displayName={me.display_name}
+        email={me.email}
+        platformRole={me.platform_role}
+      />
+      <main className="container space-y-6 py-8">
+        <h1 className="text-2xl font-semibold tracking-tight">Datasets</h1>
+
+        <form method="GET" className="rounded-lg border p-4">
+          <div className="grid gap-3 md:grid-cols-4">
+            <Input
+              name="q"
+              defaultValue={q}
+              placeholder="Search by name"
+              className="md:col-span-2"
+            />
+            <select
+              name="source_type"
+              defaultValue={sourceType}
+              className="h-10 rounded-md border bg-background px-3 text-sm"
+            >
+              <option value="">All source types</option>
+              {sourceTypes.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+            <Input name="limit" type="number" min={1} max={50} defaultValue={limit} />
+          </div>
+          <div className="mt-3">
+            <Button type="submit">Apply</Button>
+          </div>
+        </form>
+
+        {errorMessage ? (
+          <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive">
+            {errorMessage}
+          </div>
+        ) : null}
+
+        {!errorMessage ? (
+          <div className="rounded-lg border">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/50">
+                  <th className="px-4 py-3 text-left font-medium">Name</th>
+                  <th className="px-4 py-3 text-left font-medium">Source</th>
+                  <th className="px-4 py-3 text-left font-medium">Rows</th>
+                  <th className="px-4 py-3 text-left font-medium">Last Updated</th>
+                </tr>
+              </thead>
+              <tbody>
+                {datasets.map((d) => (
+                  <tr key={d.id} className="border-b last:border-0">
+                    <td className="px-4 py-3">
+                      <Link
+                        href={`/datasets/${d.id}`}
+                        className="font-medium underline-offset-2 hover:underline"
+                      >
+                        {d.name}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3">{d.source_type}</td>
+                    <td className="px-4 py-3">{d.row_count ?? "-"}</td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      {d.last_updated_at
+                        ? new Date(d.last_updated_at).toLocaleString()
+                        : "-"}
+                    </td>
+                  </tr>
+                ))}
+                {datasets.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={4}
+                      className="px-4 py-8 text-center text-muted-foreground"
+                    >
+                      No datasets found.
+                    </td>
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+
+        <div className="flex items-center justify-between">
+          {hasPrev ? (
+            <Link href={buildPageHref(page - 1)}>
+              <Button variant="outline">Previous</Button>
+            </Link>
+          ) : (
+            <Button variant="outline" disabled>
+              Previous
+            </Button>
+          )}
+          <span className="text-sm text-muted-foreground">Page {page}</span>
+          {hasNext ? (
+            <Link href={buildPageHref(page + 1)}>
+              <Button variant="outline">Next</Button>
+            </Link>
+          ) : (
+            <Button variant="outline" disabled>
+              Next
+            </Button>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/node/web/src/middleware.ts
+++ b/apps/node/web/src/middleware.ts
@@ -9,6 +9,7 @@ export function middleware(request: NextRequest) {
   // Protect authenticated routes
   if (
     (pathname.startsWith("/dashboard") ||
+      pathname.startsWith("/datasets") ||
       pathname.startsWith("/connections") ||
       pathname.startsWith("/admin")) &&
     !token
@@ -33,6 +34,7 @@ export function middleware(request: NextRequest) {
 export const config = {
   matcher: [
     "/dashboard/:path*",
+    "/datasets/:path*",
     "/connections/:path*",
     "/admin/:path*",
     "/signin",


### PR DESCRIPTION
## Summary
- add `/datasets` page with tenant-scoped list, search, source filter, and pagination
- add `/datasets/[id]` detail page with schema_json, row_count, source_type, last_updated_at
- add web API proxy routes for datasets list/detail
- add datasets nav link and middleware protection for `/datasets/*`
- add error/empty-state handling for datasets list and detail pages

## Verification
- npm run build (apps/node/web)
- local run on port 3901 with `API_BACKEND_URL=http://localhost:8980`
  - unauthenticated `/datasets` redirects to signin
  - authenticated `/datasets` returns 200
  - `/api/datasets` returns 200
  - `/datasets/not-found-id` shows error message without layout break

Closes #24