### PR TITLE
feat(notification): add email notification with SendGrid provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,13 @@ FF_DATASETS_API=true
 FF_ADMIN_TENANTS=true
 FF_UPLOADS_API=true
 
+# === Notification ===
+# provider: "sendgrid" or "log" (default: log)
+NOTIFICATION_PROVIDER=log
+SENDGRID_API_KEY=
+NOTIFICATION_FROM_ADDRESS=noreply@example.com
+NOTIFICATION_FROM_NAME=micro-dp
+
 # === Frontend ===
 API_BACKEND_URL=http://localhost:8080
 NEXT_PUBLIC_TRACKER_ENDPOINT=http://localhost:8080/api/v1/events

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ internal/      — private packages:
   observability/   — OpenTelemetry traces + Prometheus metrics
   openapi/         — oapi-codegen generated types/interfaces
   featureflag/     — OpenFeature feature flag infrastructure
+  notification/    — Email notification (SendGrid / log provider)
 ```
 
 依存方向: `handler/` → `usecase/` → `domain/` ← `db/`, `queue/`。`domain/` は他パッケージに依存しない。
@@ -131,6 +132,15 @@ Internal container ports are fixed; only host-side ports change per environment.
 | `FF_DATASETS_API` | `true` | Datasets API |
 | `FF_ADMIN_TENANTS` | `true` | Admin テナント管理 |
 | `FF_UPLOADS_API` | `true` | Uploads API |
+
+### Notification
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `NOTIFICATION_PROVIDER` | `log` | メール送信プロバイダ (`sendgrid` or `log`) |
+| `SENDGRID_API_KEY` | — | SendGrid API キー (`sendgrid` 時のみ必須) |
+| `NOTIFICATION_FROM_ADDRESS` | `noreply@example.com` | 送信元メールアドレス |
+| `NOTIFICATION_FROM_NAME` | `micro-dp` | 送信元表示名 |
 
 ## Health Checks
 
@@ -432,4 +442,40 @@ featureflag.LogStartup(ffCfg)
 if featureflag.IsEnabled(featureflag.FlagEventsIngest) {
     // feature enabled
 }
+```
+
+## Notification
+
+メール通知基盤。送信プロバイダを環境変数 (`NOTIFICATION_PROVIDER`) で切替可能。開発環境は `log` (ログ出力のみ)、本番は `sendgrid` を使用。
+
+### アーキテクチャ
+
+```
+AuthService.Register() → notification.RenderWelcome() → EmailSender.Send()
+                                                            ↓
+                                                  logSender (dev) or sendGridSender (prod)
+```
+
+- 同期送信: usecase 内で直接送信（シンプルさ優先）
+- 送信失敗時はログ出力のみ（リクエスト自体は失敗させない）
+- SendGrid 実装: 最大 3 回試行 (500ms → 1s backoff)
+
+### パッケージ構成
+
+| ファイル | 役割 |
+|---------|------|
+| `internal/notification/notification.go` | EmailSender interface, Config, LoadConfig, NewEmailSender, LogStartup |
+| `internal/notification/log_sender.go` | ログ出力のみの開発用実装 |
+| `internal/notification/sendgrid_sender.go` | SendGrid API 実装 (リトライ付き) |
+| `internal/notification/templates.go` | `//go:embed` テンプレートレンダリング |
+| `internal/notification/templates/welcome.html` | ウェルカムメール HTML テンプレート |
+
+### 初期化パターン
+
+`cmd/api/main.go` で featureflag 初期化の直後に呼び出し:
+
+```go
+notifCfg := notification.LoadConfig()
+emailSender := notification.NewEmailSender(notifCfg)
+notification.LogStartup(notifCfg)
 ```

--- a/apps/golang/backend/cmd/api/main.go
+++ b/apps/golang/backend/cmd/api/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/user/micro-dp/db"
 	"github.com/user/micro-dp/handler"
 	"github.com/user/micro-dp/internal/featureflag"
+	"github.com/user/micro-dp/internal/notification"
 	"github.com/user/micro-dp/internal/observability"
 	"github.com/user/micro-dp/queue"
 	"github.com/user/micro-dp/storage"
@@ -48,6 +49,10 @@ func main() {
 	featureflag.Init(ffCfg)
 	featureflag.LogStartup(ffCfg)
 
+	notifCfg := notification.LoadConfig()
+	emailSender := notification.NewEmailSender(notifCfg)
+	notification.LogStartup(notifCfg)
+
 	jwtSecret := os.Getenv("JWT_SECRET")
 	if jwtSecret == "" {
 		log.Fatal("JWT_SECRET environment variable is required")
@@ -84,7 +89,7 @@ func main() {
 	}
 
 	// Services
-	authService := usecase.NewAuthService(userRepo, tenantRepo, jwtSecret)
+	authService := usecase.NewAuthService(userRepo, tenantRepo, jwtSecret, emailSender)
 	jobRunService := usecase.NewJobRunService(jobRunRepo, jobRepo)
 	jobService := usecase.NewJobService(jobRepo, jobVersionRepo, jobModuleRepo, jobModuleEdgeRepo, txManager)
 	moduleTypeService := usecase.NewModuleTypeService(moduleTypeRepo, moduleTypeSchemaRepo)

--- a/apps/golang/backend/cmd/bootstrap/main.go
+++ b/apps/golang/backend/cmd/bootstrap/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	userRepo := db.NewUserRepo(sqlDB)
 	tenantRepo := db.NewTenantRepo(sqlDB)
-	authService := usecase.NewAuthService(userRepo, tenantRepo, "dummy-secret-not-used")
+	authService := usecase.NewAuthService(userRepo, tenantRepo, "dummy-secret-not-used", nil)
 
 	ctx := context.Background()
 	user, err := userRepo.FindByEmail(ctx, *email)

--- a/apps/golang/backend/go.mod
+++ b/apps/golang/backend/go.mod
@@ -43,6 +43,8 @@ require (
 	github.com/redis/go-redis/v9 v9.18.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rs/xid v1.6.0 // indirect
+	github.com/sendgrid/rest v2.6.9+incompatible // indirect
+	github.com/sendgrid/sendgrid-go v3.16.1+incompatible // indirect
 	github.com/tinylib/msgp v1.6.1 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/apps/golang/backend/go.sum
+++ b/apps/golang/backend/go.sum
@@ -85,6 +85,10 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
+github.com/sendgrid/rest v2.6.9+incompatible h1:1EyIcsNdn9KIisLW50MKwmSRSK+ekueiEMJ7NEoxJo0=
+github.com/sendgrid/rest v2.6.9+incompatible/go.mod h1:kXX7q3jZtJXK5c5qK83bSGMdV6tsOE70KbHoqJls4lE=
+github.com/sendgrid/sendgrid-go v3.16.1+incompatible h1:zWhTmB0Y8XCDzeWIm2/BIt1GjJohAA0p6hVEaDtHWWs=
+github.com/sendgrid/sendgrid-go v3.16.1+incompatible/go.mod h1:QRQt+LX/NmgVEvmdRw0VT/QgUn499+iza2FnDca9fg8=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/apps/golang/backend/internal/notification/log_sender.go
+++ b/apps/golang/backend/internal/notification/log_sender.go
@@ -1,0 +1,17 @@
+package notification
+
+import (
+	"context"
+	"log"
+)
+
+type logSender struct{}
+
+func newLogSender() *logSender {
+	return &logSender{}
+}
+
+func (s *logSender) Send(_ context.Context, msg *EmailMessage) error {
+	log.Printf("notification [log] to=%s subject=%q body_len=%d", msg.To, msg.Subject, len(msg.HTML))
+	return nil
+}

--- a/apps/golang/backend/internal/notification/notification.go
+++ b/apps/golang/backend/internal/notification/notification.go
@@ -1,0 +1,63 @@
+package notification
+
+import (
+	"context"
+	"log"
+	"os"
+)
+
+// EmailMessage represents an email to be sent.
+type EmailMessage struct {
+	To      string
+	Subject string
+	HTML    string
+	Text    string
+}
+
+// EmailSender sends email messages.
+type EmailSender interface {
+	Send(ctx context.Context, msg *EmailMessage) error
+}
+
+// Config holds notification settings.
+type Config struct {
+	Provider    string // "sendgrid" or "log"
+	SendGridKey string
+	FromAddress string
+	FromName    string
+}
+
+// LoadConfig reads notification configuration from environment variables.
+func LoadConfig() Config {
+	provider := os.Getenv("NOTIFICATION_PROVIDER")
+	if provider == "" {
+		provider = "log"
+	}
+	fromAddress := os.Getenv("NOTIFICATION_FROM_ADDRESS")
+	if fromAddress == "" {
+		fromAddress = "noreply@example.com"
+	}
+	fromName := os.Getenv("NOTIFICATION_FROM_NAME")
+	if fromName == "" {
+		fromName = "micro-dp"
+	}
+	return Config{
+		Provider:    provider,
+		SendGridKey: os.Getenv("SENDGRID_API_KEY"),
+		FromAddress: fromAddress,
+		FromName:    fromName,
+	}
+}
+
+// NewEmailSender creates an EmailSender based on Config.Provider.
+func NewEmailSender(cfg Config) EmailSender {
+	if cfg.Provider == "sendgrid" {
+		return newSendGridSender(cfg)
+	}
+	return newLogSender()
+}
+
+// LogStartup logs the notification configuration at startup.
+func LogStartup(cfg Config) {
+	log.Printf("notification initialized provider=%s from=%s", cfg.Provider, cfg.FromAddress)
+}

--- a/apps/golang/backend/internal/notification/sendgrid_sender.go
+++ b/apps/golang/backend/internal/notification/sendgrid_sender.go
@@ -1,0 +1,54 @@
+package notification
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/sendgrid/sendgrid-go"
+	"github.com/sendgrid/sendgrid-go/helpers/mail"
+)
+
+type sendGridSender struct {
+	client      *sendgrid.Client
+	fromAddress string
+	fromName    string
+}
+
+func newSendGridSender(cfg Config) *sendGridSender {
+	return &sendGridSender{
+		client:      sendgrid.NewSendClient(cfg.SendGridKey),
+		fromAddress: cfg.FromAddress,
+		fromName:    cfg.FromName,
+	}
+}
+
+func (s *sendGridSender) Send(ctx context.Context, msg *EmailMessage) error {
+	from := mail.NewEmail(s.fromName, s.fromAddress)
+	to := mail.NewEmail("", msg.To)
+	m := mail.NewSingleEmail(from, msg.Subject, to, msg.Text, msg.HTML)
+
+	var lastErr error
+	for attempt := range 3 {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		resp, err := s.client.SendWithContext(ctx, m)
+		if err != nil {
+			lastErr = err
+		} else if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return nil
+		} else {
+			lastErr = fmt.Errorf("sendgrid: status=%d body=%s", resp.StatusCode, resp.Body)
+		}
+
+		log.Printf("sendgrid attempt %d failed: %v", attempt+1, lastErr)
+		if attempt < 2 {
+			delay := time.Duration(attempt+1) * 500 * time.Millisecond
+			time.Sleep(delay)
+		}
+	}
+	return lastErr
+}

--- a/apps/golang/backend/internal/notification/templates.go
+++ b/apps/golang/backend/internal/notification/templates.go
@@ -1,0 +1,44 @@
+package notification
+
+import (
+	"bytes"
+	"embed"
+	"html/template"
+	"regexp"
+	"strings"
+)
+
+//go:embed templates/*.html
+var templateFS embed.FS
+
+var tmpl = template.Must(template.ParseFS(templateFS, "templates/*.html"))
+
+var htmlTagRe = regexp.MustCompile(`<[^>]*>`)
+
+type welcomeData struct {
+	DisplayName string
+}
+
+// RenderWelcome renders the welcome email template.
+func RenderWelcome(displayName string) (subject, html, text string, err error) {
+	var buf bytes.Buffer
+	if err = tmpl.ExecuteTemplate(&buf, "welcome.html", welcomeData{DisplayName: displayName}); err != nil {
+		return "", "", "", err
+	}
+	html = buf.String()
+	text = htmlToPlainText(html)
+	subject = "Welcome to micro-dp!"
+	return subject, html, text, nil
+}
+
+func htmlToPlainText(s string) string {
+	s = strings.ReplaceAll(s, "<br>", "\n")
+	s = strings.ReplaceAll(s, "<br/>", "\n")
+	s = strings.ReplaceAll(s, "<br />", "\n")
+	s = strings.ReplaceAll(s, "</p>", "\n\n")
+	s = strings.ReplaceAll(s, "</h1>", "\n")
+	s = strings.ReplaceAll(s, "</h2>", "\n")
+	s = htmlTagRe.ReplaceAllString(s, "")
+	s = strings.TrimSpace(s)
+	return s
+}

--- a/apps/golang/backend/internal/notification/templates/welcome.html
+++ b/apps/golang/backend/internal/notification/templates/welcome.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Welcome to micro-dp</title>
+</head>
+<body style="margin:0;padding:0;font-family:Arial,Helvetica,sans-serif;background-color:#f4f4f4;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background-color:#f4f4f4;padding:20px 0;">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;">
+          <tr>
+            <td style="background-color:#1a1a2e;padding:30px;text-align:center;">
+              <h1 style="color:#ffffff;margin:0;font-size:24px;">micro-dp</h1>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:40px 30px;">
+              <h2 style="color:#333333;margin:0 0 20px 0;">Welcome, {{.DisplayName}}!</h2>
+              <p style="color:#666666;font-size:16px;line-height:1.6;margin:0 0 20px 0;">
+                Thank you for signing up for micro-dp. Your account is ready to use.
+              </p>
+              <p style="color:#666666;font-size:16px;line-height:1.6;margin:0;">
+                You can now create data pipelines, manage connections, and start ingesting events.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="background-color:#f8f8f8;padding:20px 30px;text-align:center;">
+              <p style="color:#999999;font-size:12px;margin:0;">
+                This is an automated message from micro-dp.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `internal/notification/` package with `EmailSender` interface and provider abstraction (`sendgrid` / `log`)
- SendGrid sender with retry (3 attempts, exponential backoff); log sender for development (default)
- Welcome email sent on user registration (fire-and-forget: failures logged, don't block registration)
- HTML email templates via `//go:embed`
- Initialization follows existing `LoadConfig → NewEmailSender → LogStartup` pattern

## Test plan
- [ ] `CGO_ENABLED=1 go build ./...` — backend builds
- [ ] `cd apps/golang/e2e-cli && go build ./...` — e2e-cli builds
- [ ] `make down && make up && make health` — services start
- [ ] Startup log shows `notification initialized provider=log from=noreply@example.com`
- [ ] Register user → API log shows `notification [log] to=... subject="Welcome to micro-dp!"`
- [ ] `make e2e-cli` — existing E2E tests pass

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)