### PR TITLE
feat(plan): Plan/Usage/Quota system + FF cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,14 +124,11 @@ Internal container ports are fixed; only host-side ports change per environment.
 | `MINIO_ROOT_PASSWORD` | `minioadmin` | MinIO 認証 |
 | `MINIO_BUCKET` | `micro-dp` | MinIO バケット名 |
 
-### Feature Flags
+### Edition
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
-| `FF_EVENTS_INGEST` | `true` | Events 取り込み |
-| `FF_DATASETS_API` | `true` | Datasets API |
-| `FF_ADMIN_TENANTS` | `true` | Admin テナント管理 |
-| `FF_UPLOADS_API` | `true` | Uploads API |
+| `EDITION` | `oss` | エディション (`oss` or `web`)。`web` 時のみクォータ適用 |
 
 ### Notification
 
@@ -208,6 +205,8 @@ Internal container ports are fixed; only host-side ports change per environment.
 | GET | `/api/v1/datasets/{id}` | Get dataset |
 | POST | `/api/v1/uploads/presign` | Request presigned upload URLs |
 | POST | `/api/v1/uploads/{id}/complete` | Mark upload complete |
+| GET | `/api/v1/plan` | Current tenant plan |
+| GET | `/api/v1/usage/summary` | Today's usage summary |
 
 ### Admin (Bearer + Superadmin)
 
@@ -216,6 +215,10 @@ Internal container ports are fixed; only host-side ports change per environment.
 | POST | `/api/v1/admin/tenants` | Create tenant |
 | GET | `/api/v1/admin/tenants` | List tenants |
 | PATCH | `/api/v1/admin/tenants/{id}` | Update tenant |
+| POST | `/api/v1/admin/plans` | Create plan |
+| GET | `/api/v1/admin/plans` | List plans |
+| PUT | `/api/v1/admin/plans/{id}` | Update plan |
+| POST | `/api/v1/admin/tenants/{tenant_id}/plan` | Assign plan to tenant |
 
 ## Events Ingest Pipeline
 
@@ -423,12 +426,7 @@ OpenFeature ベースの feature flag 基盤。初期は環境変数プロバイ
 
 ### フラグ一覧
 
-| Flag 定数 | 環境変数 | デフォルト | 対象機能 |
-|-----------|---------|-----------|---------|
-| `events_ingest` | `FF_EVENTS_INGEST` | `true` | Events 取り込み |
-| `datasets_api` | `FF_DATASETS_API` | `true` | Datasets API |
-| `admin_tenants` | `FF_ADMIN_TENANTS` | `true` | Admin テナント管理 |
-| `uploads_api` | `FF_UPLOADS_API` | `true` | Uploads API |
+現在アクティブなフラグはなし。`AllFlags` に追加して `FF_*` 環境変数で制御可能。
 
 ### 初期化パターン
 

--- a/apps/docker/docker-compose.yaml
+++ b/apps/docker/docker-compose.yaml
@@ -74,10 +74,7 @@ services:
       OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME_API:-micro-dp-api}
       BOOTSTRAP_SUPERADMINS: ${BOOTSTRAP_SUPERADMINS:-false}
       SUPERADMIN_EMAILS: ${SUPERADMIN_EMAILS:-}
-      FF_EVENTS_INGEST: ${FF_EVENTS_INGEST:-true}
-      FF_DATASETS_API: ${FF_DATASETS_API:-true}
-      FF_ADMIN_TENANTS: ${FF_ADMIN_TENANTS:-true}
-      FF_UPLOADS_API: ${FF_UPLOADS_API:-true}
+      EDITION: ${EDITION:-oss}
     volumes:
       - ./.data/sqlite:/data/sqlite
     depends_on:
@@ -111,10 +108,7 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
       OTEL_EXPORTER_OTLP_INSECURE: ${OTEL_EXPORTER_OTLP_INSECURE:-true}
       OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME_WORKER:-micro-dp-worker}
-      FF_EVENTS_INGEST: ${FF_EVENTS_INGEST:-true}
-      FF_DATASETS_API: ${FF_DATASETS_API:-true}
-      FF_ADMIN_TENANTS: ${FF_ADMIN_TENANTS:-true}
-      FF_UPLOADS_API: ${FF_UPLOADS_API:-true}
+      EDITION: ${EDITION:-oss}
     volumes:
       - ./.data/sqlite:/data/sqlite
     depends_on:

--- a/apps/golang/backend/cmd/api/main.go
+++ b/apps/golang/backend/cmd/api/main.go
@@ -85,6 +85,10 @@ func main() {
 	jobRunModuleRepo := db.NewJobRunModuleRepo(sqlDB)
 	jobRunArtifactRepo := db.NewJobRunArtifactRepo(sqlDB)
 
+	planRepo := db.NewPlanRepo(sqlDB)
+	tenantPlanRepo := db.NewTenantPlanRepo(sqlDB)
+	usageRepo := db.NewUsageRepo(sqlDB)
+
 	// Bootstrap superadmins
 	bootstrapCfg := usecase.ParseBootstrapConfig(os.Getenv("BOOTSTRAP_SUPERADMINS"), os.Getenv("SUPERADMIN_EMAILS"))
 	if err := usecase.BootstrapSuperadmins(context.Background(), userRepo, bootstrapCfg); err != nil {
@@ -100,6 +104,7 @@ func main() {
 	datasetService := usecase.NewDatasetService(datasetRepo)
 	eventService := usecase.NewEventService(eventQueue)
 	eventMetrics := observability.NewEventMetrics()
+	planService := usecase.NewPlanService(planRepo, tenantPlanRepo, usageRepo)
 
 	minioPresignClient, err := storage.NewMinIOPresignClient()
 	if err != nil {
@@ -119,11 +124,13 @@ func main() {
 	moduleTypeH := handler.NewModuleTypeHandler(moduleTypeService)
 	connectionH := handler.NewConnectionHandler(connectionService)
 	datasetH := handler.NewDatasetHandler(datasetService)
-	eventH := handler.NewEventHandler(eventService, eventMetrics)
-	uploadH := handler.NewUploadHandler(uploadService)
+	eventH := handler.NewEventHandler(eventService, planService, eventMetrics)
+	uploadH := handler.NewUploadHandler(uploadService, planService)
 	jobRunModuleH := handler.NewJobRunModuleHandler(jobRunModuleService)
 	jobRunArtifactH := handler.NewJobRunArtifactHandler(jobRunArtifactService)
 	adminTenantH := handler.NewAdminTenantHandler(adminTenantService)
+	planH := handler.NewPlanHandler(planService)
+	adminPlanH := handler.NewAdminPlanHandler(planService)
 
 	// Middleware
 	authMW := handler.AuthMiddleware(jwtSecret)
@@ -201,10 +208,20 @@ func main() {
 	mux.Handle("POST /api/v1/uploads/presign", protected(uploadH.Presign))
 	mux.Handle("POST /api/v1/uploads/{id}/complete", protected(uploadH.Complete))
 
+	// Plan & Usage
+	mux.Handle("GET /api/v1/plan", protected(planH.GetPlan))
+	mux.Handle("GET /api/v1/usage/summary", protected(planH.GetUsageSummary))
+
 	// Admin tenants
 	mux.Handle("POST /api/v1/admin/tenants", adminProtected(adminTenantH.Create))
 	mux.Handle("GET /api/v1/admin/tenants", adminProtected(adminTenantH.List))
 	mux.Handle("PATCH /api/v1/admin/tenants/{id}", adminProtected(adminTenantH.Patch))
+
+	// Admin plans
+	mux.Handle("POST /api/v1/admin/plans", adminProtected(adminPlanH.Create))
+	mux.Handle("GET /api/v1/admin/plans", adminProtected(adminPlanH.List))
+	mux.Handle("PUT /api/v1/admin/plans/{id}", adminProtected(adminPlanH.Update))
+	mux.Handle("POST /api/v1/admin/tenants/{tenant_id}/plan", adminProtected(adminPlanH.AssignPlan))
 
 	addr := ":8080"
 	log.Printf("api server starting on %s", addr)

--- a/apps/golang/backend/db/migrations/000010_plan_usage.down.sql
+++ b/apps/golang/backend/db/migrations/000010_plan_usage.down.sql
@@ -1,0 +1,1 @@
+-- down migration intentionally empty

--- a/apps/golang/backend/db/migrations/000010_plan_usage.up.sql
+++ b/apps/golang/backend/db/migrations/000010_plan_usage.up.sql
@@ -1,0 +1,55 @@
+-- Plans: quota template
+CREATE TABLE IF NOT EXISTS plans (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    display_name TEXT NOT NULL,
+    max_events_per_day INTEGER NOT NULL DEFAULT -1,
+    max_storage_bytes BIGINT NOT NULL DEFAULT -1,
+    max_rows_per_day INTEGER NOT NULL DEFAULT -1,
+    max_uploads_per_day INTEGER NOT NULL DEFAULT -1,
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Tenant ↔ Plan mapping
+CREATE TABLE IF NOT EXISTS tenant_plans (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL REFERENCES tenants(id),
+    plan_id TEXT NOT NULL REFERENCES plans(id),
+    started_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at DATETIME,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(tenant_id)
+);
+
+-- Daily usage counters (upsert pattern)
+CREATE TABLE IF NOT EXISTS usage_daily (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL REFERENCES tenants(id),
+    date TEXT NOT NULL,
+    events_count INTEGER NOT NULL DEFAULT 0,
+    storage_bytes BIGINT NOT NULL DEFAULT 0,
+    rows_count INTEGER NOT NULL DEFAULT 0,
+    uploads_count INTEGER NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(tenant_id, date)
+);
+
+-- Usage event log (append-only audit)
+CREATE TABLE IF NOT EXISTS usage_events (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL REFERENCES tenants(id),
+    event_type TEXT NOT NULL,
+    delta INTEGER NOT NULL,
+    recorded_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_usage_daily_tenant_date ON usage_daily(tenant_id, date);
+CREATE INDEX IF NOT EXISTS idx_usage_events_tenant ON usage_events(tenant_id, recorded_at);
+
+-- Seed: default OSS plan (unlimited)
+INSERT OR IGNORE INTO plans (id, name, display_name, max_events_per_day, max_storage_bytes, max_rows_per_day, max_uploads_per_day, is_default)
+VALUES ('plan-oss-default', 'oss', 'OSS (Unlimited)', -1, -1, -1, -1, TRUE);

--- a/apps/golang/backend/db/plan_repo.go
+++ b/apps/golang/backend/db/plan_repo.go
@@ -1,0 +1,151 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/user/micro-dp/domain"
+)
+
+// --- PlanRepo ---
+
+type PlanRepo struct {
+	db DBTX
+}
+
+func NewPlanRepo(db DBTX) *PlanRepo {
+	return &PlanRepo{db: db}
+}
+
+func scanPlan(s interface{ Scan(...any) error }) (*domain.Plan, error) {
+	var p domain.Plan
+	if err := s.Scan(
+		&p.ID, &p.Name, &p.DisplayName,
+		&p.MaxEventsPerDay, &p.MaxStorageBytes, &p.MaxRowsPerDay, &p.MaxUploadsPerDay,
+		&p.IsDefault, &p.CreatedAt, &p.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+const planColumns = `id, name, display_name, max_events_per_day, max_storage_bytes, max_rows_per_day, max_uploads_per_day, is_default, created_at, updated_at`
+
+func (r *PlanRepo) FindByID(ctx context.Context, id string) (*domain.Plan, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT `+planColumns+` FROM plans WHERE id = ?`, id,
+	)
+	p, err := scanPlan(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, domain.ErrPlanNotFound
+		}
+		return nil, err
+	}
+	return p, nil
+}
+
+func (r *PlanRepo) FindByName(ctx context.Context, name string) (*domain.Plan, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT `+planColumns+` FROM plans WHERE name = ?`, name,
+	)
+	p, err := scanPlan(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, domain.ErrPlanNotFound
+		}
+		return nil, err
+	}
+	return p, nil
+}
+
+func (r *PlanRepo) FindDefault(ctx context.Context) (*domain.Plan, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT `+planColumns+` FROM plans WHERE is_default = TRUE LIMIT 1`,
+	)
+	p, err := scanPlan(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, domain.ErrPlanNotFound
+		}
+		return nil, err
+	}
+	return p, nil
+}
+
+func (r *PlanRepo) ListAll(ctx context.Context) ([]domain.Plan, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT `+planColumns+` FROM plans ORDER BY name`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var plans []domain.Plan
+	for rows.Next() {
+		p, err := scanPlan(rows)
+		if err != nil {
+			return nil, err
+		}
+		plans = append(plans, *p)
+	}
+	return plans, rows.Err()
+}
+
+func (r *PlanRepo) Create(ctx context.Context, p *domain.Plan) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO plans (id, name, display_name, max_events_per_day, max_storage_bytes, max_rows_per_day, max_uploads_per_day, is_default, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))`,
+		p.ID, p.Name, p.DisplayName, p.MaxEventsPerDay, p.MaxStorageBytes, p.MaxRowsPerDay, p.MaxUploadsPerDay, p.IsDefault,
+	)
+	return err
+}
+
+func (r *PlanRepo) Update(ctx context.Context, p *domain.Plan) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE plans SET name = ?, display_name = ?, max_events_per_day = ?, max_storage_bytes = ?, max_rows_per_day = ?, max_uploads_per_day = ?, is_default = ?, updated_at = datetime('now')
+		 WHERE id = ?`,
+		p.Name, p.DisplayName, p.MaxEventsPerDay, p.MaxStorageBytes, p.MaxRowsPerDay, p.MaxUploadsPerDay, p.IsDefault, p.ID,
+	)
+	return err
+}
+
+// --- TenantPlanRepo ---
+
+type TenantPlanRepo struct {
+	db DBTX
+}
+
+func NewTenantPlanRepo(db DBTX) *TenantPlanRepo {
+	return &TenantPlanRepo{db: db}
+}
+
+func (r *TenantPlanRepo) FindByTenantID(ctx context.Context, tenantID string) (*domain.TenantPlan, error) {
+	var tp domain.TenantPlan
+	row := r.db.QueryRowContext(ctx,
+		`SELECT id, tenant_id, plan_id, started_at, expires_at, created_at, updated_at
+		 FROM tenant_plans WHERE tenant_id = ?`, tenantID,
+	)
+	if err := row.Scan(&tp.ID, &tp.TenantID, &tp.PlanID, &tp.StartedAt, &tp.ExpiresAt, &tp.CreatedAt, &tp.UpdatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, domain.ErrTenantPlanNotFound
+		}
+		return nil, err
+	}
+	return &tp, nil
+}
+
+func (r *TenantPlanRepo) Upsert(ctx context.Context, tp *domain.TenantPlan) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO tenant_plans (id, tenant_id, plan_id, started_at, expires_at, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+		 ON CONFLICT(tenant_id) DO UPDATE SET
+		   plan_id = excluded.plan_id,
+		   started_at = excluded.started_at,
+		   expires_at = excluded.expires_at,
+		   updated_at = datetime('now')`,
+		tp.ID, tp.TenantID, tp.PlanID, tp.StartedAt, tp.ExpiresAt,
+	)
+	return err
+}

--- a/apps/golang/backend/db/usage_repo.go
+++ b/apps/golang/backend/db/usage_repo.go
@@ -1,0 +1,93 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/google/uuid"
+	"github.com/user/micro-dp/domain"
+)
+
+type UsageRepo struct {
+	db DBTX
+}
+
+func NewUsageRepo(db DBTX) *UsageRepo {
+	return &UsageRepo{db: db}
+}
+
+func (r *UsageRepo) IncrementEvents(ctx context.Context, tenantID, date string, delta int) error {
+	id := uuid.NewString()
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO usage_daily (id, tenant_id, date, events_count, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
+		 ON CONFLICT(tenant_id, date) DO UPDATE SET
+		   events_count = events_count + ?,
+		   updated_at = datetime('now')`,
+		id, tenantID, date, delta, delta,
+	)
+	return err
+}
+
+func (r *UsageRepo) IncrementStorage(ctx context.Context, tenantID, date string, deltaBytes int64) error {
+	id := uuid.NewString()
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO usage_daily (id, tenant_id, date, storage_bytes, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
+		 ON CONFLICT(tenant_id, date) DO UPDATE SET
+		   storage_bytes = storage_bytes + ?,
+		   updated_at = datetime('now')`,
+		id, tenantID, date, deltaBytes, deltaBytes,
+	)
+	return err
+}
+
+func (r *UsageRepo) IncrementRows(ctx context.Context, tenantID, date string, delta int) error {
+	id := uuid.NewString()
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO usage_daily (id, tenant_id, date, rows_count, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
+		 ON CONFLICT(tenant_id, date) DO UPDATE SET
+		   rows_count = rows_count + ?,
+		   updated_at = datetime('now')`,
+		id, tenantID, date, delta, delta,
+	)
+	return err
+}
+
+func (r *UsageRepo) IncrementUploads(ctx context.Context, tenantID, date string, delta int) error {
+	id := uuid.NewString()
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO usage_daily (id, tenant_id, date, uploads_count, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, datetime('now'), datetime('now'))
+		 ON CONFLICT(tenant_id, date) DO UPDATE SET
+		   uploads_count = uploads_count + ?,
+		   updated_at = datetime('now')`,
+		id, tenantID, date, delta, delta,
+	)
+	return err
+}
+
+func (r *UsageRepo) FindDailyByTenantAndDate(ctx context.Context, tenantID, date string) (*domain.UsageDaily, error) {
+	var u domain.UsageDaily
+	row := r.db.QueryRowContext(ctx,
+		`SELECT id, tenant_id, date, events_count, storage_bytes, rows_count, uploads_count, created_at, updated_at
+		 FROM usage_daily WHERE tenant_id = ? AND date = ?`, tenantID, date,
+	)
+	if err := row.Scan(&u.ID, &u.TenantID, &u.Date, &u.EventsCount, &u.StorageBytes, &u.RowsCount, &u.UploadsCount, &u.CreatedAt, &u.UpdatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &u, nil
+}
+
+func (r *UsageRepo) RecordEvent(ctx context.Context, e *domain.UsageEvent) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO usage_events (id, tenant_id, event_type, delta, recorded_at)
+		 VALUES (?, ?, ?, ?, datetime('now'))`,
+		e.ID, e.TenantID, e.EventType, e.Delta,
+	)
+	return err
+}

--- a/apps/golang/backend/domain/plan.go
+++ b/apps/golang/backend/domain/plan.go
@@ -1,0 +1,49 @@
+package domain
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	ErrPlanNotFound       = errors.New("plan not found")
+	ErrTenantPlanNotFound = errors.New("tenant plan not found")
+)
+
+type Plan struct {
+	ID               string
+	Name             string
+	DisplayName      string
+	MaxEventsPerDay  int
+	MaxStorageBytes  int64
+	MaxRowsPerDay    int
+	MaxUploadsPerDay int
+	IsDefault        bool
+	CreatedAt        time.Time
+	UpdatedAt        time.Time
+}
+
+type TenantPlan struct {
+	ID        string
+	TenantID  string
+	PlanID    string
+	StartedAt time.Time
+	ExpiresAt *time.Time
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type PlanRepository interface {
+	FindByID(ctx context.Context, id string) (*Plan, error)
+	FindByName(ctx context.Context, name string) (*Plan, error)
+	FindDefault(ctx context.Context) (*Plan, error)
+	ListAll(ctx context.Context) ([]Plan, error)
+	Create(ctx context.Context, p *Plan) error
+	Update(ctx context.Context, p *Plan) error
+}
+
+type TenantPlanRepository interface {
+	FindByTenantID(ctx context.Context, tenantID string) (*TenantPlan, error)
+	Upsert(ctx context.Context, tp *TenantPlan) error
+}

--- a/apps/golang/backend/domain/usage.go
+++ b/apps/golang/backend/domain/usage.go
@@ -1,0 +1,54 @@
+package domain
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var ErrQuotaExceeded = errors.New("quota exceeded")
+
+const (
+	UsageTypeEventsIngest  = "events_ingest"
+	UsageTypeUploadComplete = "upload_complete"
+	UsageTypeStorageWrite  = "storage_write"
+)
+
+type UsageDaily struct {
+	ID           string
+	TenantID     string
+	Date         string
+	EventsCount  int
+	StorageBytes int64
+	RowsCount    int
+	UploadsCount int
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+type UsageEvent struct {
+	ID         string
+	TenantID   string
+	EventType  string
+	Delta      int
+	RecordedAt time.Time
+}
+
+type UsageSummary struct {
+	TenantID     string
+	Date         string
+	EventsCount  int
+	StorageBytes int64
+	RowsCount    int
+	UploadsCount int
+	Plan         *Plan
+}
+
+type UsageRepository interface {
+	IncrementEvents(ctx context.Context, tenantID, date string, delta int) error
+	IncrementStorage(ctx context.Context, tenantID, date string, deltaBytes int64) error
+	IncrementRows(ctx context.Context, tenantID, date string, delta int) error
+	IncrementUploads(ctx context.Context, tenantID, date string, delta int) error
+	FindDailyByTenantAndDate(ctx context.Context, tenantID, date string) (*UsageDaily, error)
+	RecordEvent(ctx context.Context, e *UsageEvent) error
+}

--- a/apps/golang/backend/handler/admin_plan.go
+++ b/apps/golang/backend/handler/admin_plan.go
@@ -1,0 +1,130 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/user/micro-dp/domain"
+	"github.com/user/micro-dp/internal/openapi"
+	"github.com/user/micro-dp/usecase"
+)
+
+type AdminPlanHandler struct {
+	plans *usecase.PlanService
+}
+
+func NewAdminPlanHandler(plans *usecase.PlanService) *AdminPlanHandler {
+	return &AdminPlanHandler{plans: plans}
+}
+
+func (h *AdminPlanHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var req openapi.CreatePlanRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name is required")
+		return
+	}
+	if req.DisplayName == "" {
+		writeError(w, http.StatusBadRequest, "display_name is required")
+		return
+	}
+
+	maxEvents := -1
+	if req.MaxEventsPerDay != nil {
+		maxEvents = *req.MaxEventsPerDay
+	}
+	maxRows := -1
+	if req.MaxRowsPerDay != nil {
+		maxRows = *req.MaxRowsPerDay
+	}
+	maxUploads := -1
+	if req.MaxUploadsPerDay != nil {
+		maxUploads = *req.MaxUploadsPerDay
+	}
+	var maxStorage int64 = -1
+	if req.MaxStorageBytes != nil {
+		maxStorage = *req.MaxStorageBytes
+	}
+
+	plan, err := h.plans.CreatePlan(r.Context(), req.Name, req.DisplayName, maxEvents, maxRows, maxUploads, maxStorage)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusCreated, toOpenAPIPlan(plan))
+}
+
+func (h *AdminPlanHandler) List(w http.ResponseWriter, r *http.Request) {
+	plans, err := h.plans.ListPlans(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	if plans == nil {
+		plans = []domain.Plan{}
+	}
+	items := make([]openapi.Plan, len(plans))
+	for i := range plans {
+		items[i] = toOpenAPIPlan(&plans[i])
+	}
+	writeJSON(w, http.StatusOK, struct {
+		Items []openapi.Plan `json:"items"`
+	}{Items: items})
+}
+
+func (h *AdminPlanHandler) Update(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing id")
+		return
+	}
+
+	var req openapi.UpdatePlanRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	plan, err := h.plans.UpdatePlan(r.Context(), id, req.DisplayName, req.MaxEventsPerDay, req.MaxRowsPerDay, req.MaxUploadsPerDay, req.MaxStorageBytes)
+	if err != nil {
+		if errors.Is(err, domain.ErrPlanNotFound) {
+			writeError(w, http.StatusNotFound, "plan not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, toOpenAPIPlan(plan))
+}
+
+func (h *AdminPlanHandler) AssignPlan(w http.ResponseWriter, r *http.Request) {
+	tenantID := r.PathValue("tenant_id")
+	if tenantID == "" {
+		writeError(w, http.StatusBadRequest, "missing tenant_id")
+		return
+	}
+
+	var req openapi.AssignPlanRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.PlanId == "" {
+		writeError(w, http.StatusBadRequest, "plan_id is required")
+		return
+	}
+
+	plan, tp, err := h.plans.AssignPlan(r.Context(), tenantID, req.PlanId)
+	if err != nil {
+		if errors.Is(err, domain.ErrPlanNotFound) {
+			writeError(w, http.StatusNotFound, "plan not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, toOpenAPITenantPlanResponse(plan, tp))
+}

--- a/apps/golang/backend/handler/convert.go
+++ b/apps/golang/backend/handler/convert.go
@@ -201,6 +201,45 @@ func toOpenAPIJobRunArtifact(a *domain.JobRunArtifact) openapi.JobRunArtifact {
 	return out
 }
 
+func toOpenAPIPlan(p *domain.Plan) openapi.Plan {
+	return openapi.Plan{
+		Id:               p.ID,
+		Name:             p.Name,
+		DisplayName:      p.DisplayName,
+		MaxEventsPerDay:  p.MaxEventsPerDay,
+		MaxStorageBytes:  p.MaxStorageBytes,
+		MaxRowsPerDay:    p.MaxRowsPerDay,
+		MaxUploadsPerDay: p.MaxUploadsPerDay,
+		IsDefault:        p.IsDefault,
+	}
+}
+
+func toOpenAPITenantPlanResponse(p *domain.Plan, tp *domain.TenantPlan) openapi.TenantPlanResponse {
+	resp := openapi.TenantPlanResponse{
+		Plan:      toOpenAPIPlan(p),
+		StartedAt: tp.StartedAt,
+	}
+	if tp.ExpiresAt != nil {
+		resp.ExpiresAt = tp.ExpiresAt
+	}
+	return resp
+}
+
+func toOpenAPIUsageSummary(s *domain.UsageSummary) openapi.UsageSummaryResponse {
+	resp := openapi.UsageSummaryResponse{
+		Date:         s.Date,
+		EventsCount:  s.EventsCount,
+		StorageBytes: s.StorageBytes,
+		RowsCount:    s.RowsCount,
+		UploadsCount: s.UploadsCount,
+	}
+	if s.Plan != nil {
+		p := toOpenAPIPlan(s.Plan)
+		resp.Plan = &p
+	}
+	return resp
+}
+
 func toOpenAPIConnection(c *domain.Connection) openapi.Connection {
 	out := openapi.Connection{
 		Id:       c.ID,

--- a/apps/golang/backend/handler/plan.go
+++ b/apps/golang/backend/handler/plan.go
@@ -1,0 +1,33 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/user/micro-dp/usecase"
+)
+
+type PlanHandler struct {
+	plans *usecase.PlanService
+}
+
+func NewPlanHandler(plans *usecase.PlanService) *PlanHandler {
+	return &PlanHandler{plans: plans}
+}
+
+func (h *PlanHandler) GetPlan(w http.ResponseWriter, r *http.Request) {
+	plan, tp, err := h.plans.GetTenantPlan(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, toOpenAPITenantPlanResponse(plan, tp))
+}
+
+func (h *PlanHandler) GetUsageSummary(w http.ResponseWriter, r *http.Request) {
+	summary, err := h.plans.GetUsageSummary(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+	writeJSON(w, http.StatusOK, toOpenAPIUsageSummary(summary))
+}

--- a/apps/golang/backend/internal/edition/edition.go
+++ b/apps/golang/backend/internal/edition/edition.go
@@ -1,0 +1,22 @@
+package edition
+
+import (
+	"os"
+	"strings"
+)
+
+const (
+	OSS = "oss"
+	Web = "web"
+)
+
+func Current() string {
+	e := strings.ToLower(strings.TrimSpace(os.Getenv("EDITION")))
+	if e == Web {
+		return Web
+	}
+	return OSS
+}
+
+func IsOSS() bool { return Current() == OSS }
+func IsWeb() bool { return Current() == Web }

--- a/apps/golang/backend/internal/featureflag/featureflag.go
+++ b/apps/golang/backend/internal/featureflag/featureflag.go
@@ -11,16 +11,8 @@ import (
 	"github.com/open-feature/go-sdk/openfeature"
 )
 
-// Flag constants for feature flags.
-const (
-	FlagEventsIngest = "events_ingest"
-	FlagDatasetsAPI  = "datasets_api"
-	FlagAdminTenants = "admin_tenants"
-	FlagUploadsAPI   = "uploads_api"
-)
-
-// AllFlags lists every known flag key.
-var AllFlags = []string{FlagEventsIngest, FlagDatasetsAPI, FlagAdminTenants, FlagUploadsAPI}
+// AllFlags lists every known flag key. Add new flags here.
+var AllFlags []string
 
 // Config holds the resolved flag values.
 type Config struct {

--- a/apps/golang/backend/internal/openapi/server.gen.go
+++ b/apps/golang/backend/internal/openapi/server.gen.go
@@ -17,6 +17,15 @@ import (
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// List plans (superadmin only)
+	// (GET /api/v1/admin/plans)
+	AdminListPlans(w http.ResponseWriter, r *http.Request)
+	// Create plan (superadmin only)
+	// (POST /api/v1/admin/plans)
+	AdminCreatePlan(w http.ResponseWriter, r *http.Request)
+	// Update plan (superadmin only)
+	// (PUT /api/v1/admin/plans/{id})
+	AdminUpdatePlan(w http.ResponseWriter, r *http.Request, id string)
 	// List tenants (superadmin only)
 	// (GET /api/v1/admin/tenants)
 	AdminListTenants(w http.ResponseWriter, r *http.Request)
@@ -26,6 +35,9 @@ type ServerInterface interface {
 	// Update tenant (superadmin only)
 	// (PATCH /api/v1/admin/tenants/{id})
 	AdminUpdateTenant(w http.ResponseWriter, r *http.Request, id string)
+	// Assign plan to tenant (superadmin only)
+	// (POST /api/v1/admin/tenants/{tenant_id}/plan)
+	AdminAssignPlan(w http.ResponseWriter, r *http.Request, tenantId string)
 	// Login
 	// (POST /api/v1/auth/login)
 	Login(w http.ResponseWriter, r *http.Request)
@@ -122,12 +134,18 @@ type ServerInterface interface {
 	// Create module type schema version
 	// (POST /api/v1/module_types/{id}/schemas)
 	CreateModuleTypeSchema(w http.ResponseWriter, r *http.Request, id string, params CreateModuleTypeSchemaParams)
+	// Get current tenant plan
+	// (GET /api/v1/plan)
+	GetTenantPlan(w http.ResponseWriter, r *http.Request, params GetTenantPlanParams)
 	// Request presigned upload URLs
 	// (POST /api/v1/uploads/presign)
 	CreateUploadPresign(w http.ResponseWriter, r *http.Request, params CreateUploadPresignParams)
 	// Mark upload complete
 	// (POST /api/v1/uploads/{id}/complete)
 	CompleteUpload(w http.ResponseWriter, r *http.Request, id string, params CompleteUploadParams)
+	// Get today's usage summary
+	// (GET /api/v1/usage/summary)
+	GetUsageSummary(w http.ResponseWriter, r *http.Request, params GetUsageSummaryParams)
 	// Health check
 	// (GET /healthz)
 	GetHealthz(w http.ResponseWriter, r *http.Request)
@@ -141,6 +159,77 @@ type ServerInterfaceWrapper struct {
 }
 
 type MiddlewareFunc func(http.Handler) http.Handler
+
+// AdminListPlans operation middleware
+func (siw *ServerInterfaceWrapper) AdminListPlans(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.AdminListPlans(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// AdminCreatePlan operation middleware
+func (siw *ServerInterfaceWrapper) AdminCreatePlan(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.AdminCreatePlan(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// AdminUpdatePlan operation middleware
+func (siw *ServerInterfaceWrapper) AdminUpdatePlan(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.AdminUpdatePlan(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
 
 // AdminListTenants operation middleware
 func (siw *ServerInterfaceWrapper) AdminListTenants(w http.ResponseWriter, r *http.Request) {
@@ -204,6 +293,37 @@ func (siw *ServerInterfaceWrapper) AdminUpdateTenant(w http.ResponseWriter, r *h
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.AdminUpdateTenant(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// AdminAssignPlan operation middleware
+func (siw *ServerInterfaceWrapper) AdminAssignPlan(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "tenant_id" -------------
+	var tenantId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "tenant_id", r.PathValue("tenant_id"), &tenantId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tenant_id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.AdminAssignPlan(w, r, tenantId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1949,6 +2069,56 @@ func (siw *ServerInterfaceWrapper) CreateModuleTypeSchema(w http.ResponseWriter,
 	handler.ServeHTTP(w, r)
 }
 
+// GetTenantPlan operation middleware
+func (siw *ServerInterfaceWrapper) GetTenantPlan(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetTenantPlanParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetTenantPlan(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // CreateUploadPresign operation middleware
 func (siw *ServerInterfaceWrapper) CreateUploadPresign(w http.ResponseWriter, r *http.Request) {
 
@@ -2049,6 +2219,56 @@ func (siw *ServerInterfaceWrapper) CompleteUpload(w http.ResponseWriter, r *http
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.CompleteUpload(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetUsageSummary operation middleware
+func (siw *ServerInterfaceWrapper) GetUsageSummary(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetUsageSummaryParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetUsageSummary(w, r, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2192,9 +2412,13 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 		ErrorHandlerFunc:   options.ErrorHandlerFunc,
 	}
 
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/admin/plans", wrapper.AdminListPlans)
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1/admin/plans", wrapper.AdminCreatePlan)
+	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/admin/plans/{id}", wrapper.AdminUpdatePlan)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/admin/tenants", wrapper.AdminListTenants)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/admin/tenants", wrapper.AdminCreateTenant)
 	m.HandleFunc("PATCH "+options.BaseURL+"/api/v1/admin/tenants/{id}", wrapper.AdminUpdateTenant)
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1/admin/tenants/{tenant_id}/plan", wrapper.AdminAssignPlan)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/auth/login", wrapper.Login)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/auth/me", wrapper.Me)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/auth/register", wrapper.Register)
@@ -2227,14 +2451,150 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/module_types/{id}", wrapper.GetModuleType)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/module_types/{id}/schemas", wrapper.ListModuleTypeSchemas)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/module_types/{id}/schemas", wrapper.CreateModuleTypeSchema)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/plan", wrapper.GetTenantPlan)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/uploads/presign", wrapper.CreateUploadPresign)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/uploads/{id}/complete", wrapper.CompleteUpload)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/usage/summary", wrapper.GetUsageSummary)
 	m.HandleFunc("GET "+options.BaseURL+"/healthz", wrapper.GetHealthz)
 
 	return m
 }
 
 type ErrorResponseJSONResponse ErrorResponse
+
+type AdminListPlansRequestObject struct {
+}
+
+type AdminListPlansResponseObject interface {
+	VisitAdminListPlansResponse(w http.ResponseWriter) error
+}
+
+type AdminListPlans200JSONResponse struct {
+	Items []Plan `json:"items"`
+}
+
+func (response AdminListPlans200JSONResponse) VisitAdminListPlansResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminListPlans401JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response AdminListPlans401JSONResponse) VisitAdminListPlansResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminListPlans403JSONResponse ErrorResponse
+
+func (response AdminListPlans403JSONResponse) VisitAdminListPlansResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminCreatePlanRequestObject struct {
+	Body *AdminCreatePlanJSONRequestBody
+}
+
+type AdminCreatePlanResponseObject interface {
+	VisitAdminCreatePlanResponse(w http.ResponseWriter) error
+}
+
+type AdminCreatePlan201JSONResponse Plan
+
+func (response AdminCreatePlan201JSONResponse) VisitAdminCreatePlanResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminCreatePlan400JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response AdminCreatePlan400JSONResponse) VisitAdminCreatePlanResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminCreatePlan401JSONResponse ErrorResponse
+
+func (response AdminCreatePlan401JSONResponse) VisitAdminCreatePlanResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminCreatePlan403JSONResponse ErrorResponse
+
+func (response AdminCreatePlan403JSONResponse) VisitAdminCreatePlanResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminUpdatePlanRequestObject struct {
+	Id   string `json:"id"`
+	Body *AdminUpdatePlanJSONRequestBody
+}
+
+type AdminUpdatePlanResponseObject interface {
+	VisitAdminUpdatePlanResponse(w http.ResponseWriter) error
+}
+
+type AdminUpdatePlan200JSONResponse Plan
+
+func (response AdminUpdatePlan200JSONResponse) VisitAdminUpdatePlanResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminUpdatePlan400JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response AdminUpdatePlan400JSONResponse) VisitAdminUpdatePlanResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminUpdatePlan401JSONResponse ErrorResponse
+
+func (response AdminUpdatePlan401JSONResponse) VisitAdminUpdatePlanResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminUpdatePlan403JSONResponse ErrorResponse
+
+func (response AdminUpdatePlan403JSONResponse) VisitAdminUpdatePlanResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminUpdatePlan404JSONResponse ErrorResponse
+
+func (response AdminUpdatePlan404JSONResponse) VisitAdminUpdatePlanResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
 
 type AdminListTenantsRequestObject struct {
 }
@@ -2364,6 +2724,60 @@ func (response AdminUpdateTenant403JSONResponse) VisitAdminUpdateTenantResponse(
 type AdminUpdateTenant404JSONResponse ErrorResponse
 
 func (response AdminUpdateTenant404JSONResponse) VisitAdminUpdateTenantResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminAssignPlanRequestObject struct {
+	TenantId string `json:"tenant_id"`
+	Body     *AdminAssignPlanJSONRequestBody
+}
+
+type AdminAssignPlanResponseObject interface {
+	VisitAdminAssignPlanResponse(w http.ResponseWriter) error
+}
+
+type AdminAssignPlan200JSONResponse TenantPlanResponse
+
+func (response AdminAssignPlan200JSONResponse) VisitAdminAssignPlanResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminAssignPlan400JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response AdminAssignPlan400JSONResponse) VisitAdminAssignPlanResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminAssignPlan401JSONResponse ErrorResponse
+
+func (response AdminAssignPlan401JSONResponse) VisitAdminAssignPlanResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminAssignPlan403JSONResponse ErrorResponse
+
+func (response AdminAssignPlan403JSONResponse) VisitAdminAssignPlanResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminAssignPlan404JSONResponse ErrorResponse
+
+func (response AdminAssignPlan404JSONResponse) VisitAdminAssignPlanResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(404)
 
@@ -2760,6 +3174,15 @@ type IngestEvent401JSONResponse ErrorResponse
 func (response IngestEvent401JSONResponse) VisitIngestEventResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type IngestEvent402JSONResponse ErrorResponse
+
+func (response IngestEvent402JSONResponse) VisitIngestEventResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(402)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -3528,6 +3951,32 @@ func (response CreateModuleTypeSchema404JSONResponse) VisitCreateModuleTypeSchem
 	return json.NewEncoder(w).Encode(response)
 }
 
+type GetTenantPlanRequestObject struct {
+	Params GetTenantPlanParams
+}
+
+type GetTenantPlanResponseObject interface {
+	VisitGetTenantPlanResponse(w http.ResponseWriter) error
+}
+
+type GetTenantPlan200JSONResponse TenantPlanResponse
+
+func (response GetTenantPlan200JSONResponse) VisitGetTenantPlanResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetTenantPlan401JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response GetTenantPlan401JSONResponse) VisitGetTenantPlanResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type CreateUploadPresignRequestObject struct {
 	Params CreateUploadPresignParams
 	Body   *CreateUploadPresignJSONRequestBody
@@ -3560,6 +4009,15 @@ type CreateUploadPresign401JSONResponse ErrorResponse
 func (response CreateUploadPresign401JSONResponse) VisitCreateUploadPresignResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateUploadPresign402JSONResponse ErrorResponse
+
+func (response CreateUploadPresign402JSONResponse) VisitCreateUploadPresignResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(402)
 
 	return json.NewEncoder(w).Encode(response)
 }
@@ -3609,6 +4067,32 @@ func (response CompleteUpload409JSONResponse) VisitCompleteUploadResponse(w http
 	return json.NewEncoder(w).Encode(response)
 }
 
+type GetUsageSummaryRequestObject struct {
+	Params GetUsageSummaryParams
+}
+
+type GetUsageSummaryResponseObject interface {
+	VisitGetUsageSummaryResponse(w http.ResponseWriter) error
+}
+
+type GetUsageSummary200JSONResponse UsageSummaryResponse
+
+func (response GetUsageSummary200JSONResponse) VisitGetUsageSummaryResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetUsageSummary401JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response GetUsageSummary401JSONResponse) VisitGetUsageSummaryResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type GetHealthzRequestObject struct {
 }
 
@@ -3627,6 +4111,15 @@ func (response GetHealthz200JSONResponse) VisitGetHealthzResponse(w http.Respons
 
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
+	// List plans (superadmin only)
+	// (GET /api/v1/admin/plans)
+	AdminListPlans(ctx context.Context, request AdminListPlansRequestObject) (AdminListPlansResponseObject, error)
+	// Create plan (superadmin only)
+	// (POST /api/v1/admin/plans)
+	AdminCreatePlan(ctx context.Context, request AdminCreatePlanRequestObject) (AdminCreatePlanResponseObject, error)
+	// Update plan (superadmin only)
+	// (PUT /api/v1/admin/plans/{id})
+	AdminUpdatePlan(ctx context.Context, request AdminUpdatePlanRequestObject) (AdminUpdatePlanResponseObject, error)
 	// List tenants (superadmin only)
 	// (GET /api/v1/admin/tenants)
 	AdminListTenants(ctx context.Context, request AdminListTenantsRequestObject) (AdminListTenantsResponseObject, error)
@@ -3636,6 +4129,9 @@ type StrictServerInterface interface {
 	// Update tenant (superadmin only)
 	// (PATCH /api/v1/admin/tenants/{id})
 	AdminUpdateTenant(ctx context.Context, request AdminUpdateTenantRequestObject) (AdminUpdateTenantResponseObject, error)
+	// Assign plan to tenant (superadmin only)
+	// (POST /api/v1/admin/tenants/{tenant_id}/plan)
+	AdminAssignPlan(ctx context.Context, request AdminAssignPlanRequestObject) (AdminAssignPlanResponseObject, error)
 	// Login
 	// (POST /api/v1/auth/login)
 	Login(ctx context.Context, request LoginRequestObject) (LoginResponseObject, error)
@@ -3732,12 +4228,18 @@ type StrictServerInterface interface {
 	// Create module type schema version
 	// (POST /api/v1/module_types/{id}/schemas)
 	CreateModuleTypeSchema(ctx context.Context, request CreateModuleTypeSchemaRequestObject) (CreateModuleTypeSchemaResponseObject, error)
+	// Get current tenant plan
+	// (GET /api/v1/plan)
+	GetTenantPlan(ctx context.Context, request GetTenantPlanRequestObject) (GetTenantPlanResponseObject, error)
 	// Request presigned upload URLs
 	// (POST /api/v1/uploads/presign)
 	CreateUploadPresign(ctx context.Context, request CreateUploadPresignRequestObject) (CreateUploadPresignResponseObject, error)
 	// Mark upload complete
 	// (POST /api/v1/uploads/{id}/complete)
 	CompleteUpload(ctx context.Context, request CompleteUploadRequestObject) (CompleteUploadResponseObject, error)
+	// Get today's usage summary
+	// (GET /api/v1/usage/summary)
+	GetUsageSummary(ctx context.Context, request GetUsageSummaryRequestObject) (GetUsageSummaryResponseObject, error)
 	// Health check
 	// (GET /healthz)
 	GetHealthz(ctx context.Context, request GetHealthzRequestObject) (GetHealthzResponseObject, error)
@@ -3770,6 +4272,94 @@ type strictHandler struct {
 	ssi         StrictServerInterface
 	middlewares []StrictMiddlewareFunc
 	options     StrictHTTPServerOptions
+}
+
+// AdminListPlans operation middleware
+func (sh *strictHandler) AdminListPlans(w http.ResponseWriter, r *http.Request) {
+	var request AdminListPlansRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.AdminListPlans(ctx, request.(AdminListPlansRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "AdminListPlans")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(AdminListPlansResponseObject); ok {
+		if err := validResponse.VisitAdminListPlansResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// AdminCreatePlan operation middleware
+func (sh *strictHandler) AdminCreatePlan(w http.ResponseWriter, r *http.Request) {
+	var request AdminCreatePlanRequestObject
+
+	var body AdminCreatePlanJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.AdminCreatePlan(ctx, request.(AdminCreatePlanRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "AdminCreatePlan")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(AdminCreatePlanResponseObject); ok {
+		if err := validResponse.VisitAdminCreatePlanResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// AdminUpdatePlan operation middleware
+func (sh *strictHandler) AdminUpdatePlan(w http.ResponseWriter, r *http.Request, id string) {
+	var request AdminUpdatePlanRequestObject
+
+	request.Id = id
+
+	var body AdminUpdatePlanJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.AdminUpdatePlan(ctx, request.(AdminUpdatePlanRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "AdminUpdatePlan")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(AdminUpdatePlanResponseObject); ok {
+		if err := validResponse.VisitAdminUpdatePlanResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
 }
 
 // AdminListTenants operation middleware
@@ -3853,6 +4443,39 @@ func (sh *strictHandler) AdminUpdateTenant(w http.ResponseWriter, r *http.Reques
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(AdminUpdateTenantResponseObject); ok {
 		if err := validResponse.VisitAdminUpdateTenantResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// AdminAssignPlan operation middleware
+func (sh *strictHandler) AdminAssignPlan(w http.ResponseWriter, r *http.Request, tenantId string) {
+	var request AdminAssignPlanRequestObject
+
+	request.TenantId = tenantId
+
+	var body AdminAssignPlanJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.AdminAssignPlan(ctx, request.(AdminAssignPlanRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "AdminAssignPlan")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(AdminAssignPlanResponseObject); ok {
+		if err := validResponse.VisitAdminAssignPlanResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -4785,6 +5408,32 @@ func (sh *strictHandler) CreateModuleTypeSchema(w http.ResponseWriter, r *http.R
 	}
 }
 
+// GetTenantPlan operation middleware
+func (sh *strictHandler) GetTenantPlan(w http.ResponseWriter, r *http.Request, params GetTenantPlanParams) {
+	var request GetTenantPlanRequestObject
+
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetTenantPlan(ctx, request.(GetTenantPlanRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetTenantPlan")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetTenantPlanResponseObject); ok {
+		if err := validResponse.VisitGetTenantPlanResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // CreateUploadPresign operation middleware
 func (sh *strictHandler) CreateUploadPresign(w http.ResponseWriter, r *http.Request, params CreateUploadPresignParams) {
 	var request CreateUploadPresignRequestObject
@@ -4838,6 +5487,32 @@ func (sh *strictHandler) CompleteUpload(w http.ResponseWriter, r *http.Request, 
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(CompleteUploadResponseObject); ok {
 		if err := validResponse.VisitCompleteUploadResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetUsageSummary operation middleware
+func (sh *strictHandler) GetUsageSummary(w http.ResponseWriter, r *http.Request, params GetUsageSummaryParams) {
+	var request GetUsageSummaryRequestObject
+
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetUsageSummary(ctx, request.(GetUsageSummaryRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetUsageSummary")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetUsageSummaryResponseObject); ok {
+		if err := validResponse.VisitGetUsageSummaryResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {

--- a/apps/golang/backend/internal/openapi/types.gen.go
+++ b/apps/golang/backend/internal/openapi/types.gen.go
@@ -92,6 +92,11 @@ type AdminUpdateTenantRequest struct {
 	Name     *string `json:"name,omitempty"`
 }
 
+// AssignPlanRequest defines model for AssignPlanRequest.
+type AssignPlanRequest struct {
+	PlanId string `json:"plan_id"`
+}
+
 // Connection defines model for Connection.
 type Connection struct {
 	ConfigJson *string    `json:"config_json,omitempty"`
@@ -160,6 +165,16 @@ type CreateModuleTypeRequestCategory string
 // CreateModuleTypeSchemaRequest defines model for CreateModuleTypeSchemaRequest.
 type CreateModuleTypeSchemaRequest struct {
 	JsonSchema string `json:"json_schema"`
+}
+
+// CreatePlanRequest defines model for CreatePlanRequest.
+type CreatePlanRequest struct {
+	DisplayName      string `json:"display_name"`
+	MaxEventsPerDay  *int   `json:"max_events_per_day,omitempty"`
+	MaxRowsPerDay    *int   `json:"max_rows_per_day,omitempty"`
+	MaxStorageBytes  *int64 `json:"max_storage_bytes,omitempty"`
+	MaxUploadsPerDay *int   `json:"max_uploads_per_day,omitempty"`
+	Name             string `json:"name"`
 }
 
 // CreateUploadPresignRequest defines model for CreateUploadPresignRequest.
@@ -390,6 +405,18 @@ type ModuleTypeSchema struct {
 	Version      int        `json:"version"`
 }
 
+// Plan defines model for Plan.
+type Plan struct {
+	DisplayName      string `json:"display_name"`
+	Id               string `json:"id"`
+	IsDefault        bool   `json:"is_default"`
+	MaxEventsPerDay  int    `json:"max_events_per_day"`
+	MaxRowsPerDay    int    `json:"max_rows_per_day"`
+	MaxStorageBytes  int64  `json:"max_storage_bytes"`
+	MaxUploadsPerDay int    `json:"max_uploads_per_day"`
+	Name             string `json:"name"`
+}
+
 // RegisterRequest defines model for RegisterRequest.
 type RegisterRequest struct {
 	DisplayName *string             `json:"display_name,omitempty"`
@@ -410,6 +437,13 @@ type Tenant struct {
 	Name     string `json:"name"`
 }
 
+// TenantPlanResponse defines model for TenantPlanResponse.
+type TenantPlanResponse struct {
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	Plan      Plan       `json:"plan"`
+	StartedAt time.Time  `json:"started_at"`
+}
+
 // UpdateConnectionRequest defines model for UpdateConnectionRequest.
 type UpdateConnectionRequest struct {
 	ConfigJson *string `json:"config_json,omitempty"`
@@ -424,6 +458,15 @@ type UpdateJobRequest struct {
 	IsActive    bool    `json:"is_active"`
 	Name        string  `json:"name"`
 	Slug        string  `json:"slug"`
+}
+
+// UpdatePlanRequest defines model for UpdatePlanRequest.
+type UpdatePlanRequest struct {
+	DisplayName      *string `json:"display_name,omitempty"`
+	MaxEventsPerDay  *int    `json:"max_events_per_day,omitempty"`
+	MaxRowsPerDay    *int    `json:"max_rows_per_day,omitempty"`
+	MaxStorageBytes  *int64  `json:"max_storage_bytes,omitempty"`
+	MaxUploadsPerDay *int    `json:"max_uploads_per_day,omitempty"`
 }
 
 // Upload defines model for Upload.
@@ -465,6 +508,16 @@ type UploadFilePresigned struct {
 
 // UploadStatus defines model for UploadStatus.
 type UploadStatus string
+
+// UsageSummaryResponse defines model for UsageSummaryResponse.
+type UsageSummaryResponse struct {
+	Date         string `json:"date"`
+	EventsCount  int    `json:"events_count"`
+	Plan         *Plan  `json:"plan,omitempty"`
+	RowsCount    int    `json:"rows_count"`
+	StorageBytes int64  `json:"storage_bytes"`
+	UploadsCount int    `json:"uploads_count"`
+}
 
 // XTenantID defines model for XTenantID.
 type XTenantID = string
@@ -619,6 +672,11 @@ type CreateModuleTypeSchemaParams struct {
 	XTenantID XTenantID `json:"X-Tenant-ID"`
 }
 
+// GetTenantPlanParams defines parameters for GetTenantPlan.
+type GetTenantPlanParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
 // CreateUploadPresignParams defines parameters for CreateUploadPresign.
 type CreateUploadPresignParams struct {
 	XTenantID XTenantID `json:"X-Tenant-ID"`
@@ -629,11 +687,25 @@ type CompleteUploadParams struct {
 	XTenantID XTenantID `json:"X-Tenant-ID"`
 }
 
+// GetUsageSummaryParams defines parameters for GetUsageSummary.
+type GetUsageSummaryParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// AdminCreatePlanJSONRequestBody defines body for AdminCreatePlan for application/json ContentType.
+type AdminCreatePlanJSONRequestBody = CreatePlanRequest
+
+// AdminUpdatePlanJSONRequestBody defines body for AdminUpdatePlan for application/json ContentType.
+type AdminUpdatePlanJSONRequestBody = UpdatePlanRequest
+
 // AdminCreateTenantJSONRequestBody defines body for AdminCreateTenant for application/json ContentType.
 type AdminCreateTenantJSONRequestBody = AdminCreateTenantRequest
 
 // AdminUpdateTenantJSONRequestBody defines body for AdminUpdateTenant for application/json ContentType.
 type AdminUpdateTenantJSONRequestBody = AdminUpdateTenantRequest
+
+// AdminAssignPlanJSONRequestBody defines body for AdminAssignPlan for application/json ContentType.
+type AdminAssignPlanJSONRequestBody = AssignPlanRequest
 
 // LoginJSONRequestBody defines body for Login for application/json ContentType.
 type LoginJSONRequestBody = LoginRequest

--- a/apps/golang/backend/usecase/metering.go
+++ b/apps/golang/backend/usecase/metering.go
@@ -1,0 +1,81 @@
+package usecase
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/user/micro-dp/domain"
+)
+
+type MeteringService struct {
+	usage domain.UsageRepository
+}
+
+func NewMeteringService(usage domain.UsageRepository) *MeteringService {
+	return &MeteringService{usage: usage}
+}
+
+func today() string {
+	return time.Now().UTC().Format("2006-01-02")
+}
+
+// RecordEvents records event ingest usage (called by Worker, best-effort).
+func (s *MeteringService) RecordEvents(ctx context.Context, tenantID string, count int) error {
+	date := today()
+	if err := s.usage.IncrementEvents(ctx, tenantID, date, count); err != nil {
+		return err
+	}
+	return s.usage.RecordEvent(ctx, &domain.UsageEvent{
+		ID:        uuid.New().String(),
+		TenantID:  tenantID,
+		EventType: domain.UsageTypeEventsIngest,
+		Delta:     count,
+	})
+}
+
+// RecordUpload records upload rows + storage usage (called by Worker, best-effort).
+func (s *MeteringService) RecordUpload(ctx context.Context, tenantID string, rowCount int, storageBytes int64) error {
+	date := today()
+	if err := s.usage.IncrementRows(ctx, tenantID, date, rowCount); err != nil {
+		return err
+	}
+	if err := s.usage.IncrementStorage(ctx, tenantID, date, storageBytes); err != nil {
+		return err
+	}
+	return s.usage.RecordEvent(ctx, &domain.UsageEvent{
+		ID:        uuid.New().String(),
+		TenantID:  tenantID,
+		EventType: domain.UsageTypeStorageWrite,
+		Delta:     rowCount,
+	})
+}
+
+// RecordUploadCount increments the daily upload counter by 1.
+func (s *MeteringService) RecordUploadCount(ctx context.Context, tenantID string) error {
+	date := today()
+	if err := s.usage.IncrementUploads(ctx, tenantID, date, 1); err != nil {
+		return err
+	}
+	return s.usage.RecordEvent(ctx, &domain.UsageEvent{
+		ID:        uuid.New().String(),
+		TenantID:  tenantID,
+		EventType: domain.UsageTypeUploadComplete,
+		Delta:     1,
+	})
+}
+
+// RecordEventsBestEffort logs errors but does not return them.
+func (s *MeteringService) RecordEventsBestEffort(ctx context.Context, tenantID string, count int) {
+	if err := s.RecordEvents(ctx, tenantID, count); err != nil {
+		log.Printf("metering record events error tenant=%s: %v", tenantID, err)
+	}
+}
+
+// RecordUploadBestEffort logs errors but does not return them.
+func (s *MeteringService) RecordUploadBestEffort(ctx context.Context, tenantID string, rowCount int, storageBytes int64) {
+	if err := s.RecordUpload(ctx, tenantID, rowCount, storageBytes); err != nil {
+		log.Printf("metering record upload error tenant=%s: %v", tenantID, err)
+	}
+}

--- a/apps/golang/backend/usecase/plan.go
+++ b/apps/golang/backend/usecase/plan.go
@@ -1,0 +1,216 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/user/micro-dp/domain"
+	"github.com/user/micro-dp/internal/edition"
+)
+
+type PlanService struct {
+	plans       domain.PlanRepository
+	tenantPlans domain.TenantPlanRepository
+	usage       domain.UsageRepository
+}
+
+func NewPlanService(plans domain.PlanRepository, tenantPlans domain.TenantPlanRepository, usage domain.UsageRepository) *PlanService {
+	return &PlanService{plans: plans, tenantPlans: tenantPlans, usage: usage}
+}
+
+// GetTenantPlan returns the plan for the tenant. Falls back to default plan if not assigned.
+func (s *PlanService) GetTenantPlan(ctx context.Context) (*domain.Plan, *domain.TenantPlan, error) {
+	tenantID, ok := domain.TenantIDFromContext(ctx)
+	if !ok {
+		return nil, nil, fmt.Errorf("tenant id not found in context")
+	}
+
+	tp, err := s.tenantPlans.FindByTenantID(ctx, tenantID)
+	if err != nil && !errors.Is(err, domain.ErrTenantPlanNotFound) {
+		return nil, nil, err
+	}
+
+	if tp != nil {
+		plan, err := s.plans.FindByID(ctx, tp.PlanID)
+		if err != nil {
+			return nil, nil, err
+		}
+		return plan, tp, nil
+	}
+
+	// No explicit assignment — use default plan
+	plan, err := s.plans.FindDefault(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	now := time.Now().UTC()
+	defaultTP := &domain.TenantPlan{
+		TenantID:  tenantID,
+		PlanID:    plan.ID,
+		StartedAt: now,
+	}
+	return plan, defaultTP, nil
+}
+
+// GetUsageSummary returns today's usage + current plan.
+func (s *PlanService) GetUsageSummary(ctx context.Context) (*domain.UsageSummary, error) {
+	tenantID, ok := domain.TenantIDFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("tenant id not found in context")
+	}
+
+	date := today()
+	daily, err := s.usage.FindDailyByTenantAndDate(ctx, tenantID, date)
+	if err != nil {
+		return nil, err
+	}
+
+	plan, _, err := s.GetTenantPlan(ctx)
+	if err != nil && !errors.Is(err, domain.ErrPlanNotFound) {
+		return nil, err
+	}
+
+	summary := &domain.UsageSummary{
+		TenantID: tenantID,
+		Date:     date,
+		Plan:     plan,
+	}
+	if daily != nil {
+		summary.EventsCount = daily.EventsCount
+		summary.StorageBytes = daily.StorageBytes
+		summary.RowsCount = daily.RowsCount
+		summary.UploadsCount = daily.UploadsCount
+	}
+	return summary, nil
+}
+
+// CheckEventsQuota checks if the tenant is within the events quota.
+// OSS edition always returns nil (no quota).
+func (s *PlanService) CheckEventsQuota(ctx context.Context) error {
+	if edition.IsOSS() {
+		return nil
+	}
+	return s.checkQuota(ctx, func(plan *domain.Plan, daily *domain.UsageDaily) bool {
+		if plan.MaxEventsPerDay < 0 {
+			return false // unlimited
+		}
+		current := 0
+		if daily != nil {
+			current = daily.EventsCount
+		}
+		return current >= plan.MaxEventsPerDay
+	})
+}
+
+// CheckUploadQuota checks if the tenant is within the upload quota.
+// OSS edition always returns nil (no quota).
+func (s *PlanService) CheckUploadQuota(ctx context.Context) error {
+	if edition.IsOSS() {
+		return nil
+	}
+	return s.checkQuota(ctx, func(plan *domain.Plan, daily *domain.UsageDaily) bool {
+		if plan.MaxUploadsPerDay < 0 {
+			return false // unlimited
+		}
+		current := 0
+		if daily != nil {
+			current = daily.UploadsCount
+		}
+		return current >= plan.MaxUploadsPerDay
+	})
+}
+
+func (s *PlanService) checkQuota(ctx context.Context, exceeded func(*domain.Plan, *domain.UsageDaily) bool) error {
+	tenantID, ok := domain.TenantIDFromContext(ctx)
+	if !ok {
+		return fmt.Errorf("tenant id not found in context")
+	}
+
+	plan, _, err := s.GetTenantPlan(ctx)
+	if err != nil {
+		if errors.Is(err, domain.ErrPlanNotFound) {
+			return nil // no plan = no quota
+		}
+		return err
+	}
+
+	date := today()
+	daily, err := s.usage.FindDailyByTenantAndDate(ctx, tenantID, date)
+	if err != nil {
+		return err
+	}
+
+	if exceeded(plan, daily) {
+		return domain.ErrQuotaExceeded
+	}
+	return nil
+}
+
+// --- Admin operations ---
+
+func (s *PlanService) CreatePlan(ctx context.Context, name, displayName string, maxEvents, maxRows, maxUploads int, maxStorage int64) (*domain.Plan, error) {
+	p := &domain.Plan{
+		ID:               uuid.New().String(),
+		Name:             name,
+		DisplayName:      displayName,
+		MaxEventsPerDay:  maxEvents,
+		MaxStorageBytes:  maxStorage,
+		MaxRowsPerDay:    maxRows,
+		MaxUploadsPerDay: maxUploads,
+	}
+	if err := s.plans.Create(ctx, p); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+func (s *PlanService) ListPlans(ctx context.Context) ([]domain.Plan, error) {
+	return s.plans.ListAll(ctx)
+}
+
+func (s *PlanService) UpdatePlan(ctx context.Context, id string, displayName *string, maxEvents, maxRows, maxUploads *int, maxStorage *int64) (*domain.Plan, error) {
+	plan, err := s.plans.FindByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if displayName != nil {
+		plan.DisplayName = *displayName
+	}
+	if maxEvents != nil {
+		plan.MaxEventsPerDay = *maxEvents
+	}
+	if maxStorage != nil {
+		plan.MaxStorageBytes = *maxStorage
+	}
+	if maxRows != nil {
+		plan.MaxRowsPerDay = *maxRows
+	}
+	if maxUploads != nil {
+		plan.MaxUploadsPerDay = *maxUploads
+	}
+	if err := s.plans.Update(ctx, plan); err != nil {
+		return nil, err
+	}
+	return plan, nil
+}
+
+func (s *PlanService) AssignPlan(ctx context.Context, tenantID, planID string) (*domain.Plan, *domain.TenantPlan, error) {
+	plan, err := s.plans.FindByID(ctx, planID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tp := &domain.TenantPlan{
+		ID:        uuid.New().String(),
+		TenantID:  tenantID,
+		PlanID:    planID,
+		StartedAt: time.Now().UTC(),
+	}
+	if err := s.tenantPlans.Upsert(ctx, tp); err != nil {
+		return nil, nil, err
+	}
+	return plan, tp, nil
+}

--- a/apps/node/web/src/lib/api/generated.ts
+++ b/apps/node/web/src/lib/api/generated.ts
@@ -141,6 +141,92 @@ export interface paths {
         patch: operations["adminUpdateTenant"];
         trace?: never;
     };
+    "/api/v1/plan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get current tenant plan */
+        get: operations["getTenantPlan"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/usage/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get today's usage summary */
+        get: operations["getUsageSummary"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/plans": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List plans (superadmin only) */
+        get: operations["adminListPlans"];
+        put?: never;
+        /** Create plan (superadmin only) */
+        post: operations["adminCreatePlan"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/plans/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update plan (superadmin only) */
+        put: operations["adminUpdatePlan"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/tenants/{tenant_id}/plan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Assign plan to tenant (superadmin only) */
+        post: operations["adminAssignPlan"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/jobs": {
         parameters: {
             query?: never;
@@ -815,6 +901,59 @@ export interface components {
             /** Format: date-time */
             updated_at?: string;
         };
+        Plan: {
+            id: string;
+            name: string;
+            display_name: string;
+            max_events_per_day: number;
+            /** Format: int64 */
+            max_storage_bytes: number;
+            max_rows_per_day: number;
+            max_uploads_per_day: number;
+            is_default: boolean;
+        };
+        TenantPlanResponse: {
+            plan: components["schemas"]["Plan"];
+            /** Format: date-time */
+            started_at: string;
+            /** Format: date-time */
+            expires_at?: string;
+        };
+        UsageSummaryResponse: {
+            date: string;
+            events_count: number;
+            /** Format: int64 */
+            storage_bytes: number;
+            rows_count: number;
+            uploads_count: number;
+            plan?: components["schemas"]["Plan"];
+        };
+        CreatePlanRequest: {
+            name: string;
+            display_name: string;
+            /** @default -1 */
+            max_events_per_day: number;
+            /**
+             * Format: int64
+             * @default -1
+             */
+            max_storage_bytes: number;
+            /** @default -1 */
+            max_rows_per_day: number;
+            /** @default -1 */
+            max_uploads_per_day: number;
+        };
+        UpdatePlanRequest: {
+            display_name?: string;
+            max_events_per_day?: number;
+            /** Format: int64 */
+            max_storage_bytes?: number;
+            max_rows_per_day?: number;
+            max_uploads_per_day?: number;
+        };
+        AssignPlanRequest: {
+            plan_id: string;
+        };
     };
     responses: {
         /** @description Error response */
@@ -955,6 +1094,7 @@ export interface operations {
             };
             400: components["responses"]["ErrorResponse"];
             401: components["responses"]["ErrorResponse"];
+            402: components["responses"]["ErrorResponse"];
             409: components["responses"]["ErrorResponse"];
         };
     };
@@ -1054,6 +1194,163 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Tenant"];
+                };
+            };
+            400: components["responses"]["ErrorResponse"];
+            401: components["responses"]["ErrorResponse"];
+            403: components["responses"]["ErrorResponse"];
+            404: components["responses"]["ErrorResponse"];
+        };
+    };
+    getTenantPlan: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current plan */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TenantPlanResponse"];
+                };
+            };
+            401: components["responses"]["ErrorResponse"];
+        };
+    };
+    getUsageSummary: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Usage summary */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UsageSummaryResponse"];
+                };
+            };
+            401: components["responses"]["ErrorResponse"];
+        };
+    };
+    adminListPlans: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of plans */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        items: components["schemas"]["Plan"][];
+                    };
+                };
+            };
+            401: components["responses"]["ErrorResponse"];
+            403: components["responses"]["ErrorResponse"];
+        };
+    };
+    adminCreatePlan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreatePlanRequest"];
+            };
+        };
+        responses: {
+            /** @description Created plan */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Plan"];
+                };
+            };
+            400: components["responses"]["ErrorResponse"];
+            401: components["responses"]["ErrorResponse"];
+            403: components["responses"]["ErrorResponse"];
+        };
+    };
+    adminUpdatePlan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdatePlanRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated plan */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Plan"];
+                };
+            };
+            400: components["responses"]["ErrorResponse"];
+            401: components["responses"]["ErrorResponse"];
+            403: components["responses"]["ErrorResponse"];
+            404: components["responses"]["ErrorResponse"];
+        };
+    };
+    adminAssignPlan: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                tenant_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AssignPlanRequest"];
+            };
+        };
+        responses: {
+            /** @description Plan assigned */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TenantPlanResponse"];
                 };
             };
             400: components["responses"]["ErrorResponse"];
@@ -1831,6 +2128,7 @@ export interface operations {
             };
             400: components["responses"]["ErrorResponse"];
             401: components["responses"]["ErrorResponse"];
+            402: components["responses"]["ErrorResponse"];
         };
     };
     completeUpload: {

--- a/spec/openapi/v1.yaml
+++ b/spec/openapi/v1.yaml
@@ -11,6 +11,8 @@ tags:
   - name: auth
   - name: events
   - name: admin
+  - name: plans
+  - name: usage
   - name: jobs
   - name: job_runs
   - name: module_types
@@ -118,6 +120,8 @@ paths:
           $ref: "#/components/responses/ErrorResponse"
         "401":
           $ref: "#/components/responses/ErrorResponse"
+        "402":
+          $ref: "#/components/responses/ErrorResponse"
         "409":
           $ref: "#/components/responses/ErrorResponse"
 
@@ -217,6 +221,163 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Tenant"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "403":
+          $ref: "#/components/responses/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+
+  # ---- Plan & Usage (tenant-scoped) ----
+  /api/v1/plan:
+    get:
+      tags: [plans]
+      summary: Get current tenant plan
+      operationId: getTenantPlan
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+      responses:
+        "200":
+          description: Current plan
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TenantPlanResponse"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+  /api/v1/usage/summary:
+    get:
+      tags: [usage]
+      summary: Get today's usage summary
+      operationId: getUsageSummary
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+      responses:
+        "200":
+          description: Usage summary
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsageSummaryResponse"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+
+  # ---- Admin Plans ----
+  /api/v1/admin/plans:
+    post:
+      tags: [admin]
+      summary: Create plan (superadmin only)
+      operationId: adminCreatePlan
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreatePlanRequest"
+      responses:
+        "201":
+          description: Created plan
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Plan"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "403":
+          $ref: "#/components/responses/ErrorResponse"
+    get:
+      tags: [admin]
+      summary: List plans (superadmin only)
+      operationId: adminListPlans
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: List of plans
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Plan"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "403":
+          $ref: "#/components/responses/ErrorResponse"
+  /api/v1/admin/plans/{id}:
+    put:
+      tags: [admin]
+      summary: Update plan (superadmin only)
+      operationId: adminUpdatePlan
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdatePlanRequest"
+      responses:
+        "200":
+          description: Updated plan
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Plan"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "403":
+          $ref: "#/components/responses/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+  /api/v1/admin/tenants/{tenant_id}/plan:
+    post:
+      tags: [admin]
+      summary: Assign plan to tenant (superadmin only)
+      operationId: adminAssignPlan
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: tenant_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AssignPlanRequest"
+      responses:
+        "200":
+          description: Plan assigned
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TenantPlanResponse"
         "400":
           $ref: "#/components/responses/ErrorResponse"
         "401":
@@ -1038,6 +1199,8 @@ paths:
           $ref: "#/components/responses/ErrorResponse"
         "401":
           $ref: "#/components/responses/ErrorResponse"
+        "402":
+          $ref: "#/components/responses/ErrorResponse"
   /api/v1/uploads/{id}/complete:
     post:
       tags: [uploads]
@@ -1726,3 +1889,96 @@ components:
         updated_at:
           type: string
           format: date-time
+
+    # ---- Plan & Usage schemas ----
+    Plan:
+      type: object
+      required: [id, name, display_name, max_events_per_day, max_storage_bytes, max_rows_per_day, max_uploads_per_day, is_default]
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        display_name:
+          type: string
+        max_events_per_day:
+          type: integer
+        max_storage_bytes:
+          type: integer
+          format: int64
+        max_rows_per_day:
+          type: integer
+        max_uploads_per_day:
+          type: integer
+        is_default:
+          type: boolean
+    TenantPlanResponse:
+      type: object
+      required: [plan, started_at]
+      properties:
+        plan:
+          $ref: "#/components/schemas/Plan"
+        started_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+    UsageSummaryResponse:
+      type: object
+      required: [date, events_count, storage_bytes, rows_count, uploads_count]
+      properties:
+        date:
+          type: string
+        events_count:
+          type: integer
+        storage_bytes:
+          type: integer
+          format: int64
+        rows_count:
+          type: integer
+        uploads_count:
+          type: integer
+        plan:
+          $ref: "#/components/schemas/Plan"
+    CreatePlanRequest:
+      type: object
+      required: [name, display_name]
+      properties:
+        name:
+          type: string
+        display_name:
+          type: string
+        max_events_per_day:
+          type: integer
+          default: -1
+        max_storage_bytes:
+          type: integer
+          format: int64
+          default: -1
+        max_rows_per_day:
+          type: integer
+          default: -1
+        max_uploads_per_day:
+          type: integer
+          default: -1
+    UpdatePlanRequest:
+      type: object
+      properties:
+        display_name:
+          type: string
+        max_events_per_day:
+          type: integer
+        max_storage_bytes:
+          type: integer
+          format: int64
+        max_rows_per_day:
+          type: integer
+        max_uploads_per_day:
+          type: integer
+    AssignPlanRequest:
+      type: object
+      required: [plan_id]
+      properties:
+        plan_id:
+          type: string


### PR DESCRIPTION
## Summary
- Remove 4 dead sample feature flag constants; keep OpenFeature infrastructure for future use
- Add `EDITION` env var (`oss`/`web`) to control quota enforcement — OSS skips all quota checks
- Add migration 000010: `plans`, `tenant_plans`, `usage_daily`, `usage_events` tables with default OSS plan seed
- Add domain types, db repositories, usecase services (`PlanService`, `MeteringService`)
- Add 6 API endpoints: tenant plan/usage (2) + admin plan CRUD & assign (4)
- Add quota checks (HTTP 402) on events ingest and uploads presign
- Add best-effort metering in Worker (`EventConsumer`, `UploadConsumer`) — failures don't block processing
- Update OpenAPI spec + regenerate Go/TS types + update CLAUDE.md

Closes #39

## Test plan
- [ ] `CGO_ENABLED=1 go build ./...` passes
- [ ] `make openapi-lint` passes
- [ ] `make down && make up && make health` — all services healthy
- [ ] Migration 000010 applies (check api logs for migration output)
- [ ] `make e2e-cli` — existing E2E tests still pass
- [ ] `GET /api/v1/plan` returns OSS plan (unlimited)
- [ ] `GET /api/v1/usage/summary` returns zero counters
- [ ] Admin plan CRUD works (`POST/GET/PUT /api/v1/admin/plans`)
- [ ] `POST /api/v1/admin/tenants/{id}/plan` assigns plan
- [ ] `grep -c "FF_" apps/docker/docker-compose.yaml` → 0
- [ ] OSS mode: no 402 returned on events/uploads (quota not enforced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)