### PR TITLE
feat(web): dynamic connector form for connections

### DIFF
--- a/apps/node/web/src/app/api/connections/test/route.ts
+++ b/apps/node/web/src/app/api/connections/test/route.ts
@@ -1,0 +1,40 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+import type { components } from "@/lib/api/generated";
+import { backendFetch } from "@/lib/api/server";
+import { TENANT_COOKIE, TOKEN_COOKIE } from "@/lib/auth/constants";
+
+type ErrorResponse = components["schemas"]["ErrorResponse"];
+
+async function authHeaders() {
+  const jar = await cookies();
+  const token = jar.get(TOKEN_COOKIE)?.value;
+  const tenantId = jar.get(TENANT_COOKIE)?.value;
+  if (!token || !tenantId) {
+    return null;
+  }
+  return {
+    Authorization: `Bearer ${token}`,
+    "X-Tenant-ID": tenantId,
+  };
+}
+
+export async function POST(request: NextRequest) {
+  const headers = await authHeaders();
+  if (!headers) {
+    return NextResponse.json(
+      { error: "not authenticated" } satisfies ErrorResponse,
+      { status: 401 }
+    );
+  }
+
+  const body = await request.json();
+  const res = await backendFetch("/api/v1/connections/test", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/node/web/src/app/api/connectors/[id]/route.ts
+++ b/apps/node/web/src/app/api/connectors/[id]/route.ts
@@ -1,0 +1,39 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+import type { components } from "@/lib/api/generated";
+import { backendFetch } from "@/lib/api/server";
+import { TENANT_COOKIE, TOKEN_COOKIE } from "@/lib/auth/constants";
+
+type ErrorResponse = components["schemas"]["ErrorResponse"];
+
+async function authHeaders() {
+  const jar = await cookies();
+  const token = jar.get(TOKEN_COOKIE)?.value;
+  const tenantId = jar.get(TENANT_COOKIE)?.value;
+  if (!token || !tenantId) {
+    return null;
+  }
+  return {
+    Authorization: `Bearer ${token}`,
+    "X-Tenant-ID": tenantId,
+  };
+}
+
+export async function GET(
+  _request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  const headers = await authHeaders();
+  if (!headers) {
+    return NextResponse.json(
+      { error: "not authenticated" } satisfies ErrorResponse,
+      { status: 401 }
+    );
+  }
+
+  const { id } = await context.params;
+  const res = await backendFetch(`/api/v1/connectors/${id}`, { headers });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/node/web/src/app/api/connectors/route.ts
+++ b/apps/node/web/src/app/api/connectors/route.ts
@@ -1,0 +1,37 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+import type { components } from "@/lib/api/generated";
+import { backendFetch } from "@/lib/api/server";
+import { TENANT_COOKIE, TOKEN_COOKIE } from "@/lib/auth/constants";
+
+type ErrorResponse = components["schemas"]["ErrorResponse"];
+
+async function authHeaders() {
+  const jar = await cookies();
+  const token = jar.get(TOKEN_COOKIE)?.value;
+  const tenantId = jar.get(TENANT_COOKIE)?.value;
+  if (!token || !tenantId) {
+    return null;
+  }
+  return {
+    Authorization: `Bearer ${token}`,
+    "X-Tenant-ID": tenantId,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const headers = await authHeaders();
+  if (!headers) {
+    return NextResponse.json(
+      { error: "not authenticated" } satisfies ErrorResponse,
+      { status: 401 }
+    );
+  }
+
+  const kind = request.nextUrl.searchParams.get("kind");
+  const query = kind ? `?kind=${encodeURIComponent(kind)}` : "";
+  const res = await backendFetch(`/api/v1/connectors${query}`, { headers });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/node/web/src/app/connections/connections-manager.tsx
+++ b/apps/node/web/src/app/connections/connections-manager.tsx
@@ -1,32 +1,36 @@
 "use client";
 
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useCallback, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { components } from "@/lib/api/generated";
+import { ConnectorSchemaForm } from "./connector-schema-form";
 
 type Connection = components["schemas"]["Connection"];
+type ConnectorDefinition = components["schemas"]["ConnectorDefinition"];
 
 type FormState = {
   name: string;
   type: string;
-  config_json: string;
+  configValues: Record<string, unknown>;
   secret_ref: string;
 };
 
 const emptyForm: FormState = {
   name: "",
   type: "",
-  config_json: "{}",
+  configValues: {},
   secret_ref: "",
 };
 
 export function ConnectionsManager({
   initialConnections,
+  initialConnectors,
 }: {
   initialConnections: Connection[];
+  initialConnectors: ConnectorDefinition[];
 }) {
   const [connections, setConnections] = useState(initialConnections);
   const [form, setForm] = useState<FormState>(emptyForm);
@@ -34,7 +38,44 @@ export function ConnectionsManager({
   const [message, setMessage] = useState<string>("");
   const [loading, setLoading] = useState(false);
 
+  // Spec fetched for the currently selected connector type
+  const [spec, setSpec] = useState<Record<string, unknown> | null>(null);
+  const [specLoading, setSpecLoading] = useState(false);
+  const [testMessage, setTestMessage] = useState<string>("");
+  const [testLoading, setTestLoading] = useState(false);
+
   const isEditing = useMemo(() => editingId !== null, [editingId]);
+
+  const fetchSpec = useCallback(async (connectorId: string) => {
+    setSpecLoading(true);
+    setSpec(null);
+    try {
+      const res = await fetch(`/api/connectors/${encodeURIComponent(connectorId)}`);
+      if (!res.ok) {
+        setSpec(null);
+        return;
+      }
+      const data = await res.json();
+      setSpec(data.spec ?? null);
+      // Apply default values from spec
+      const properties = (data.spec?.properties ?? {}) as Record<
+        string,
+        { default?: unknown }
+      >;
+      const defaults: Record<string, unknown> = {};
+      for (const [key, prop] of Object.entries(properties)) {
+        if (prop.default !== undefined) {
+          defaults[key] = prop.default;
+        }
+      }
+      setForm((prev) => ({
+        ...prev,
+        configValues: { ...defaults, ...prev.configValues },
+      }));
+    } finally {
+      setSpecLoading(false);
+    }
+  }, []);
 
   async function refreshConnections() {
     const res = await fetch("/api/connections", { cache: "no-store" });
@@ -46,6 +87,15 @@ export function ConnectionsManager({
     setConnections(data.items ?? []);
   }
 
+  function handleTypeChange(connectorId: string) {
+    setForm((prev) => ({ ...prev, type: connectorId, configValues: {} }));
+    setSpec(null);
+    setTestMessage("");
+    if (connectorId) {
+      fetchSpec(connectorId);
+    }
+  }
+
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setLoading(true);
@@ -54,7 +104,7 @@ export function ConnectionsManager({
       const payload = {
         name: form.name,
         type: form.type,
-        config_json: form.config_json || "{}",
+        config_json: JSON.stringify(form.configValues),
         secret_ref: form.secret_ref || undefined,
       };
 
@@ -75,6 +125,8 @@ export function ConnectionsManager({
       await refreshConnections();
       setForm(emptyForm);
       setEditingId(null);
+      setSpec(null);
+      setTestMessage("");
       setMessage(isEditing ? "Connection updated." : "Connection created.");
     } catch (e) {
       setMessage(e instanceof Error ? e.message : "request failed");
@@ -83,15 +135,52 @@ export function ConnectionsManager({
     }
   }
 
+  async function handleTestConnection() {
+    setTestLoading(true);
+    setTestMessage("");
+    try {
+      const res = await fetch("/api/connections/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: form.type,
+          config_json: JSON.stringify(form.configValues),
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setTestMessage(data.error ?? "Test failed");
+        return;
+      }
+      setTestMessage(
+        data.status === "ok"
+          ? "Connection test passed."
+          : `Test failed: ${data.message ?? "unknown error"}`
+      );
+    } catch (e) {
+      setTestMessage(e instanceof Error ? e.message : "request failed");
+    } finally {
+      setTestLoading(false);
+    }
+  }
+
   function beginEdit(connection: Connection) {
     setEditingId(connection.id);
+    let configValues: Record<string, unknown> = {};
+    try {
+      configValues = JSON.parse(connection.config_json ?? "{}");
+    } catch {
+      configValues = {};
+    }
     setForm({
       name: connection.name,
       type: connection.type,
-      config_json: connection.config_json ?? "{}",
+      configValues,
       secret_ref: connection.secret_ref ?? "",
     });
     setMessage("");
+    setTestMessage("");
+    fetchSpec(connection.type);
   }
 
   async function handleDelete(id: string) {
@@ -107,6 +196,8 @@ export function ConnectionsManager({
       if (editingId === id) {
         setEditingId(null);
         setForm(emptyForm);
+        setSpec(null);
+        setTestMessage("");
       }
       setMessage("Connection deleted.");
     } catch (e) {
@@ -133,39 +224,65 @@ export function ConnectionsManager({
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="type">Type</Label>
-            <Input
+            <Label htmlFor="type">
+              Type <span className="text-destructive">*</span>
+            </Label>
+            <select
               id="type"
               value={form.type}
-              onChange={(e) => setForm((prev) => ({ ...prev, type: e.target.value }))}
+              onChange={(e) => handleTypeChange(e.target.value)}
               required
-            />
-          </div>
-          <div className="space-y-2 md:col-span-2">
-            <Label htmlFor="config_json">Config JSON</Label>
-            <Input
-              id="config_json"
-              value={form.config_json}
-              onChange={(e) =>
-                setForm((prev) => ({ ...prev, config_json: e.target.value }))
-              }
-            />
-          </div>
-          <div className="space-y-2 md:col-span-2">
-            <Label htmlFor="secret_ref">Secret Ref</Label>
-            <Input
-              id="secret_ref"
-              value={form.secret_ref}
-              onChange={(e) =>
-                setForm((prev) => ({ ...prev, secret_ref: e.target.value }))
-              }
-            />
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <option value="">Select connector...</option>
+              {initialConnectors.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
           </div>
         </div>
+
+        {specLoading ? (
+          <p className="text-sm text-muted-foreground">Loading connector spec...</p>
+        ) : null}
+
+        {spec ? (
+          <ConnectorSchemaForm
+            spec={spec}
+            values={form.configValues}
+            onChange={(configValues) =>
+              setForm((prev) => ({ ...prev, configValues }))
+            }
+          />
+        ) : null}
+
+        <div className="space-y-2">
+          <Label htmlFor="secret_ref">Secret Ref</Label>
+          <Input
+            id="secret_ref"
+            value={form.secret_ref}
+            onChange={(e) =>
+              setForm((prev) => ({ ...prev, secret_ref: e.target.value }))
+            }
+          />
+        </div>
+
         <div className="flex items-center gap-2">
           <Button type="submit" disabled={loading}>
             {isEditing ? "Update" : "Create"}
           </Button>
+          {form.type ? (
+            <Button
+              type="button"
+              variant="outline"
+              disabled={testLoading || !form.type}
+              onClick={handleTestConnection}
+            >
+              {testLoading ? "Testing..." : "Test Connection"}
+            </Button>
+          ) : null}
           {isEditing ? (
             <Button
               type="button"
@@ -173,12 +290,17 @@ export function ConnectionsManager({
               onClick={() => {
                 setEditingId(null);
                 setForm(emptyForm);
+                setSpec(null);
+                setTestMessage("");
               }}
             >
               Cancel
             </Button>
           ) : null}
         </div>
+        {testMessage ? (
+          <p className="text-sm text-muted-foreground">{testMessage}</p>
+        ) : null}
         {message ? <p className="text-sm text-muted-foreground">{message}</p> : null}
       </form>
 

--- a/apps/node/web/src/app/connections/connector-schema-form.tsx
+++ b/apps/node/web/src/app/connections/connector-schema-form.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type SchemaProperty = {
+  type?: string;
+  title?: string;
+  description?: string;
+  default?: unknown;
+  enum?: string[];
+  items?: { type?: string };
+  "x-order"?: number;
+  "x-secret"?: boolean;
+  "x-multiline"?: boolean;
+  "x-group"?: string;
+  "x-visible-when"?: Record<string, string>;
+};
+
+type Spec = {
+  type?: string;
+  required?: string[];
+  properties?: Record<string, SchemaProperty>;
+};
+
+type Props = {
+  spec: Record<string, unknown>;
+  values: Record<string, unknown>;
+  onChange: (values: Record<string, unknown>) => void;
+};
+
+function humanize(key: string): string {
+  return key
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function ConnectorSchemaForm({ spec, values, onChange }: Props) {
+  const s = spec as Spec;
+  const properties = s.properties ?? {};
+  const requiredFields = new Set(s.required ?? []);
+
+  const entries = Object.entries(properties).sort(
+    ([, a], [, b]) => (a["x-order"] ?? 999) - (b["x-order"] ?? 999)
+  );
+
+  function setValue(key: string, value: unknown) {
+    onChange({ ...values, [key]: value });
+  }
+
+  // Group fields by x-group
+  const groups = new Map<string, [string, SchemaProperty][]>();
+  const ungrouped: [string, SchemaProperty][] = [];
+
+  for (const entry of entries) {
+    const group = entry[1]["x-group"];
+    if (group) {
+      if (!groups.has(group)) {
+        groups.set(group, []);
+      }
+      groups.get(group)!.push(entry);
+    } else {
+      ungrouped.push(entry);
+    }
+  }
+
+  function isVisible(prop: SchemaProperty): boolean {
+    const condition = prop["x-visible-when"];
+    if (!condition) return true;
+    return Object.entries(condition).every(
+      ([field, expected]) => values[field] === expected
+    );
+  }
+
+  function renderField(key: string, prop: SchemaProperty) {
+    if (!isVisible(prop)) return null;
+
+    const label = prop.title ?? humanize(key);
+    const isRequired = requiredFields.has(key);
+    const fieldId = `schema-${key}`;
+    const currentValue = values[key];
+
+    // Boolean → checkbox
+    if (prop.type === "boolean") {
+      return (
+        <div key={key} className="flex items-center gap-2">
+          <input
+            id={fieldId}
+            type="checkbox"
+            checked={currentValue === true}
+            onChange={(e) => setValue(key, e.target.checked)}
+            className="h-4 w-4 rounded border-gray-300"
+          />
+          <Label htmlFor={fieldId}>{label}</Label>
+          {prop.description ? (
+            <span className="text-xs text-muted-foreground">{prop.description}</span>
+          ) : null}
+        </div>
+      );
+    }
+
+    // Enum → select
+    if (prop.enum) {
+      return (
+        <div key={key} className="space-y-2">
+          <Label htmlFor={fieldId}>
+            {label}
+            {isRequired ? <span className="text-destructive"> *</span> : null}
+          </Label>
+          <select
+            id={fieldId}
+            value={(currentValue as string) ?? ""}
+            onChange={(e) => setValue(key, e.target.value)}
+            required={isRequired}
+            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <option value="">Select...</option>
+            {prop.enum.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
+          {prop.description ? (
+            <p className="text-xs text-muted-foreground">{prop.description}</p>
+          ) : null}
+        </div>
+      );
+    }
+
+    // Multiline → textarea
+    if (prop["x-multiline"]) {
+      return (
+        <div key={key} className="space-y-2">
+          <Label htmlFor={fieldId}>
+            {label}
+            {isRequired ? <span className="text-destructive"> *</span> : null}
+          </Label>
+          <textarea
+            id={fieldId}
+            value={(currentValue as string) ?? ""}
+            onChange={(e) => setValue(key, e.target.value)}
+            required={isRequired}
+            rows={4}
+            className="flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          {prop.description ? (
+            <p className="text-xs text-muted-foreground">{prop.description}</p>
+          ) : null}
+        </div>
+      );
+    }
+
+    // Number/integer → number input
+    if (prop.type === "integer" || prop.type === "number") {
+      return (
+        <div key={key} className="space-y-2">
+          <Label htmlFor={fieldId}>
+            {label}
+            {isRequired ? <span className="text-destructive"> *</span> : null}
+          </Label>
+          <Input
+            id={fieldId}
+            type="number"
+            value={currentValue !== undefined && currentValue !== null ? String(currentValue) : ""}
+            onChange={(e) => {
+              const v = e.target.value;
+              setValue(key, v === "" ? undefined : Number(v));
+            }}
+            required={isRequired}
+          />
+          {prop.description ? (
+            <p className="text-xs text-muted-foreground">{prop.description}</p>
+          ) : null}
+        </div>
+      );
+    }
+
+    // Array of strings → comma-separated input
+    if (prop.type === "array" && prop.items?.type === "string") {
+      const arr = Array.isArray(currentValue) ? currentValue : [];
+      return (
+        <div key={key} className="space-y-2">
+          <Label htmlFor={fieldId}>
+            {label}
+            {isRequired ? <span className="text-destructive"> *</span> : null}
+          </Label>
+          <Input
+            id={fieldId}
+            value={arr.join(", ")}
+            onChange={(e) => {
+              const v = e.target.value;
+              setValue(
+                key,
+                v.trim() === ""
+                  ? []
+                  : v.split(",").map((s) => s.trim())
+              );
+            }}
+            placeholder="value1, value2, ..."
+            required={isRequired}
+          />
+          {prop.description ? (
+            <p className="text-xs text-muted-foreground">{prop.description}</p>
+          ) : null}
+        </div>
+      );
+    }
+
+    // Default: string input (with x-secret support)
+    return (
+      <div key={key} className="space-y-2">
+        <Label htmlFor={fieldId}>
+          {label}
+          {isRequired ? <span className="text-destructive"> *</span> : null}
+        </Label>
+        <Input
+          id={fieldId}
+          type={prop["x-secret"] ? "password" : "text"}
+          value={(currentValue as string) ?? ""}
+          onChange={(e) => setValue(key, e.target.value)}
+          required={isRequired}
+        />
+        {prop.description ? (
+          <p className="text-xs text-muted-foreground">{prop.description}</p>
+        ) : null}
+      </div>
+    );
+  }
+
+  function renderGroup(name: string, fields: [string, SchemaProperty][]) {
+    const visibleFields = fields.filter(([, prop]) => isVisible(prop));
+    if (visibleFields.length === 0) return null;
+
+    return (
+      <div key={name} className="space-y-4 rounded-md border p-4">
+        <h3 className="text-sm font-medium">{humanize(name)}</h3>
+        <div className="grid gap-4 md:grid-cols-2">
+          {visibleFields.map(([key, prop]) => renderField(key, prop))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 md:grid-cols-2">
+        {ungrouped.map(([key, prop]) => renderField(key, prop))}
+      </div>
+      {[...groups.entries()].map(([name, fields]) => renderGroup(name, fields))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Replace free-text Type input and raw JSON config with connector definition-driven dynamic form
- Type field is now a `<select>` populated from `GET /api/v1/connectors`; selecting a connector fetches its JSON Schema spec to render typed form fields
- Add `ConnectorSchemaForm` component supporting `x-order` sorting, `x-secret` password masking, `x-visible-when` conditional visibility, enum selects, number/boolean/array inputs, `x-group` grouping, and default value population
- Add "Test Connection" button calling `POST /api/v1/connections/test`
- Add API proxy routes: connectors list, connectors detail (with spec), connection test

## Test plan

- [ ] `make down && make up && make health` — services start
- [ ] Open `http://localhost:3000/connections` — Type dropdown shows connectors (source-postgres, etc.)
- [ ] Select a connector type — dynamic form fields appear with correct input types
- [ ] Password fields render as `type="password"`
- [ ] Port default value (5432) auto-populates
- [ ] Required fields show validation on empty submit
- [ ] S3 source: `x-visible-when` shows/hides fields based on auth_method selection
- [ ] Test Connection button returns result message
- [ ] Create connection succeeds (201)
- [ ] Edit connection restores config values into dynamic form
- [ ] `make e2e-cli` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)