### PR TITLE
docs: add e2e-cli to CLAUDE.md and skills

### DIFF
--- a/.claude/skills/openapi/SKILL.md
+++ b/.claude/skills/openapi/SKILL.md
@@ -37,10 +37,11 @@ make openapi-generate
 
 ### 3. Go build
 
-生成型が handler/usecase と整合するか確認:
+生成型が handler/usecase/e2e シナリオと整合するか確認:
 
 ```bash
 cd apps/golang/backend && CGO_ENABLED=1 go build ./...
+cd apps/golang/e2e-cli && go build ./...
 ```
 
 ビルドエラーがあれば、生成型と既存コードの不整合箇所を特定して報告する。
@@ -69,3 +70,4 @@ git diff --exit-code
 生成されたファイル:
 - `apps/node/web/src/lib/api/generated.ts`
 - `apps/golang/backend/internal/openapi/*.gen.go`
+- `apps/golang/e2e-cli/internal/openapi/types.gen.go`

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -19,8 +19,11 @@ argument-hint: "[--skip-e2e]"
 
 ### 1. Go build
 
+backend と e2e-cli の両方をビルドする:
+
 ```bash
 cd apps/golang/backend && CGO_ENABLED=1 go build ./...
+cd apps/golang/e2e-cli && go build ./...
 ```
 
 ビルドが失敗した場合はエラー内容を報告して停止する。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ micro-dp is a data pipeline platform built as a monorepo. The stack is Next.js (
 **Monorepo layout by language**:
 
 - `apps/golang/backend/` — Go API + Worker
+- `apps/golang/e2e-cli/` — E2E test CLI (OpenAPI generated types)
 - `apps/node/web/` — Next.js frontend (App Router, standalone output)
 - `apps/docker/` — All Docker/Compose configuration
 - `apps/shell/` — Shell scripts (worktree env setup)
@@ -441,7 +442,8 @@ make openapi-lint         # Redocly lint for spec/openapi/v1.yaml
 make openapi-bundle       # bundle output to spec/openapi/dist/v1.bundle.yaml
 make openapi-generate-fe  # generate TS types to apps/node/web/src/lib/api/generated.ts
 make openapi-generate-be  # generate Go types/server interfaces to apps/golang/backend/internal/openapi/*.gen.go
-make openapi-generate     # run FE + BE generation
+make openapi-generate-e2e # generate Go models to apps/golang/e2e-cli/internal/openapi/types.gen.go
+make openapi-generate     # run FE + BE + E2E generation
 make openapi-check        # lint + generate + git diff --exit-code (drift detection)
 ```
 
@@ -451,7 +453,8 @@ When API contract is changed:
 
 1. Update `spec/openapi/v1.yaml`
 2. Run `make openapi-generate` (or `make openapi-check`)
-3. Commit spec and generated artifacts together
+3. Build all Go modules: `cd apps/golang/backend && go build ./...` and `cd apps/golang/e2e-cli && go build ./...`
+4. Commit spec and generated artifacts together
 
 ## Feature Flags
 


### PR DESCRIPTION
## Summary
- Add `apps/golang/e2e-cli/` to monorepo layout in CLAUDE.md
- Add `openapi-generate-e2e` target and e2e-cli build step to OpenAPI workflow docs
- Update verify and openapi skills to include e2e-cli build checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)