### PR TITLE
chore: add GitHub issue templates for feature work

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Q&A / Discussions
+    url: https://github.com/3106k/micro-dp/discussions
+    about: 質問・相談は Issue ではなく Discussions を利用してください

--- a/.github/ISSUE_TEMPLATE/feature-implementation.md
+++ b/.github/ISSUE_TEMPLATE/feature-implementation.md
@@ -1,0 +1,53 @@
+---
+name: Feature Implementation
+about: 新機能実装・拡張のIssueテンプレート
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
+## 背景
+- なぜこの機能が必要か
+- 現状の課題
+
+## 目的
+- このIssueで達成したいこと
+
+## スコープ
+### In
+- 
+
+### Out
+- 
+
+## 仕様メモ（任意）
+- 認証方式
+- データモデル
+- UI/UX 方針
+
+## API / Contract 影響
+- [ ] OpenAPI 変更なし
+- [ ] OpenAPI 変更あり（`spec/openapi/v1.yaml` を更新）
+
+OpenAPI変更がある場合:
+- [ ] `make openapi-lint`
+- [ ] `make openapi-generate`
+- [ ] `make openapi-check`
+
+## 実装タスク
+- [ ] Backend
+- [ ] Frontend
+- [ ] Test（unit/integration/e2e）
+- [ ] Docs（必要な場合）
+
+## 受け入れ条件
+- [ ] ユーザー操作で期待フローが完了する
+- [ ] 主要エラーケースで原因が識別できる
+- [ ] 既存機能の回帰がない
+
+## 依存関係
+- Depends on: #
+- Blocks: #
+
+## 補足
+- 関連Issue / 参考リンク / メモ


### PR DESCRIPTION
## Summary\n- add a reusable feature implementation issue template\n- add issue template config to disable blank issues\n- add Discussions contact link for Q&A flow\n\n## Files\n- .github/ISSUE_TEMPLATE/feature-implementation.md\n- .github/ISSUE_TEMPLATE/config.yml\n\n## Related\n- #105\n- #106\n- #107