### PR TITLE
refactor(transform): read Parquet from S3 directly via DuckDB httpfs

### DIFF
--- a/apps/golang/backend/storage/duckdb_s3.go
+++ b/apps/golang/backend/storage/duckdb_s3.go
@@ -1,0 +1,32 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// ConfigureDuckDBHTTPFS loads the httpfs extension and configures S3 credentials for DuckDB.
+func ConfigureDuckDBHTTPFS(ctx context.Context, db *sql.DB, cfg S3Config) error {
+	stmts := []string{
+		"INSTALL httpfs",
+		"LOAD httpfs",
+		fmt.Sprintf("SET s3_endpoint = '%s'", cfg.Endpoint),
+		fmt.Sprintf("SET s3_access_key_id = '%s'", cfg.AccessKey),
+		fmt.Sprintf("SET s3_secret_access_key = '%s'", cfg.SecretKey),
+		fmt.Sprintf("SET s3_use_ssl = %v", cfg.Secure),
+		"SET s3_url_style = 'path'",
+		fmt.Sprintf("SET s3_region = '%s'", cfg.Region),
+	}
+	for _, stmt := range stmts {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("duckdb httpfs setup (%s): %w", stmt, err)
+		}
+	}
+	return nil
+}
+
+// S3ParquetURI builds an s3:// URI from a bucket name and object key.
+func S3ParquetURI(bucket, objectKey string) string {
+	return fmt.Sprintf("s3://%s/%s", bucket, objectKey)
+}

--- a/apps/golang/backend/storage/minio.go
+++ b/apps/golang/backend/storage/minio.go
@@ -14,8 +14,32 @@ import (
 )
 
 type MinIOClient struct {
-	client *minio.Client
-	bucket string
+	client    *minio.Client
+	bucket    string
+	endpoint  string
+	accessKey string
+	secretKey string
+	secure    bool
+}
+
+type S3Config struct {
+	Endpoint  string
+	AccessKey string
+	SecretKey string
+	Bucket    string
+	Secure    bool
+	Region    string
+}
+
+func (m *MinIOClient) S3Config() S3Config {
+	return S3Config{
+		Endpoint:  m.endpoint,
+		AccessKey: m.accessKey,
+		SecretKey: m.secretKey,
+		Bucket:    m.bucket,
+		Secure:    m.secure,
+		Region:    "us-east-1",
+	}
 }
 
 func parseEndpoint(raw string) (string, bool, error) {
@@ -62,7 +86,14 @@ func NewMinIOClient() (*MinIOClient, error) {
 		return nil, fmt.Errorf("minio client: %w", err)
 	}
 
-	return &MinIOClient{client: client, bucket: bucket}, nil
+	return &MinIOClient{
+		client:    client,
+		bucket:    bucket,
+		endpoint:  normalizedEndpoint,
+		accessKey: accessKey,
+		secretKey: secretKey,
+		secure:    secure,
+	}, nil
 }
 
 // MinIOPresignClient generates presigned URLs for browser-direct uploads.

--- a/apps/golang/backend/usecase/transform.go
+++ b/apps/golang/backend/usecase/transform.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 
 	_ "github.com/marcboeker/go-duckdb"
@@ -81,48 +79,38 @@ type CreateTransformJobResult struct {
 	JobRun  *domain.JobRun
 }
 
-func (s *TransformService) setupDuckDB(ctx context.Context, tenantID string, datasetIDs []string) (*sql.DB, string, error) {
+func (s *TransformService) setupDuckDB(ctx context.Context, tenantID string, datasetIDs []string) (*sql.DB, error) {
 	datasets := make([]*domain.Dataset, 0, len(datasetIDs))
 	for _, id := range datasetIDs {
 		ds, err := s.datasets.FindByID(ctx, tenantID, id)
 		if err != nil {
-			return nil, "", fmt.Errorf("dataset %s: %w", id, err)
+			return nil, fmt.Errorf("dataset %s: %w", id, err)
 		}
 		datasets = append(datasets, ds)
 	}
 
-	tmpDir, err := os.MkdirTemp("", "micro-dp-transform-*")
-	if err != nil {
-		return nil, "", fmt.Errorf("create temp dir: %w", err)
-	}
-
-	// Download parquet files
-	for i, ds := range datasets {
-		localPath := filepath.Join(tmpDir, fmt.Sprintf("ds_%d.parquet", i))
-		if err := s.minio.DownloadToFile(ctx, ds.StoragePath, localPath); err != nil {
-			os.RemoveAll(tmpDir)
-			return nil, "", fmt.Errorf("download dataset %s: %w", ds.Name, err)
-		}
-	}
-
 	duckDB, err := sql.Open("duckdb", "")
 	if err != nil {
-		os.RemoveAll(tmpDir)
-		return nil, "", fmt.Errorf("open duckdb: %w", err)
+		return nil, fmt.Errorf("open duckdb: %w", err)
 	}
 
-	// Register each dataset as a VIEW
-	for i, ds := range datasets {
-		localPath := filepath.Join(tmpDir, fmt.Sprintf("ds_%d.parquet", i))
-		viewSQL := fmt.Sprintf("CREATE VIEW %s AS SELECT * FROM read_parquet('%s')", quoteIdentifier(ds.Name), localPath)
+	s3Cfg := s.minio.S3Config()
+	if err := storage.ConfigureDuckDBHTTPFS(ctx, duckDB, s3Cfg); err != nil {
+		duckDB.Close()
+		return nil, fmt.Errorf("configure httpfs: %w", err)
+	}
+
+	// Register each dataset as a VIEW reading directly from S3
+	for _, ds := range datasets {
+		uri := storage.S3ParquetURI(s3Cfg.Bucket, ds.StoragePath)
+		viewSQL := fmt.Sprintf("CREATE VIEW %s AS SELECT * FROM read_parquet('%s')", quoteIdentifier(ds.Name), uri)
 		if _, err := duckDB.ExecContext(ctx, viewSQL); err != nil {
 			duckDB.Close()
-			os.RemoveAll(tmpDir)
-			return nil, "", fmt.Errorf("create view %s: %w", ds.Name, err)
+			return nil, fmt.Errorf("create view %s: %w", ds.Name, err)
 		}
 	}
 
-	return duckDB, tmpDir, nil
+	return duckDB, nil
 }
 
 func (s *TransformService) ValidateSQL(ctx context.Context, sqlStr string, datasetIDs []string) (*ValidateResult, error) {
@@ -141,12 +129,11 @@ func (s *TransformService) ValidateSQL(ctx context.Context, sqlStr string, datas
 	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	duckDB, tmpDir, err := s.setupDuckDB(timeoutCtx, tenantID, datasetIDs)
+	duckDB, err := s.setupDuckDB(timeoutCtx, tenantID, datasetIDs)
 	if err != nil {
 		return &ValidateResult{Valid: false, Error: err.Error()}, nil
 	}
 	defer duckDB.Close()
-	defer os.RemoveAll(tmpDir)
 
 	// EXPLAIN to check syntax
 	if _, err := duckDB.ExecContext(timeoutCtx, fmt.Sprintf("EXPLAIN %s", sqlStr)); err != nil {
@@ -183,12 +170,11 @@ func (s *TransformService) PreviewSQL(ctx context.Context, sqlStr string, datase
 	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	duckDB, tmpDir, err := s.setupDuckDB(timeoutCtx, tenantID, datasetIDs)
+	duckDB, err := s.setupDuckDB(timeoutCtx, tenantID, datasetIDs)
 	if err != nil {
 		return nil, fmt.Errorf("setup duckdb: %w", err)
 	}
 	defer duckDB.Close()
-	defer os.RemoveAll(tmpDir)
 
 	query := fmt.Sprintf("SELECT * FROM (%s) AS _q LIMIT %d", sqlStr, limit)
 	rows, err := duckDB.QueryContext(timeoutCtx, query)

--- a/apps/golang/backend/worker/transform_writer.go
+++ b/apps/golang/backend/worker/transform_writer.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"time"
 
+	_ "github.com/marcboeker/go-duckdb"
+
 	"github.com/google/uuid"
 	"github.com/user/micro-dp/domain"
 	"github.com/user/micro-dp/storage"
@@ -29,6 +31,7 @@ func NewTransformWriter(minio *storage.MinIOClient, datasets domain.DatasetRepos
 }
 
 func (w *TransformWriter) Execute(ctx context.Context, msg *domain.TransformJobMessage) (*TransformResult, error) {
+	// tmpDir is only needed for output Parquet (COPY TO requires a local path)
 	tmpDir, err := os.MkdirTemp("", "micro-dp-transform-*")
 	if err != nil {
 		return nil, fmt.Errorf("create temp dir: %w", err)
@@ -45,14 +48,6 @@ func (w *TransformWriter) Execute(ctx context.Context, msg *domain.TransformJobM
 		datasets = append(datasets, ds)
 	}
 
-	// Download parquet files
-	for i, ds := range datasets {
-		localPath := filepath.Join(tmpDir, fmt.Sprintf("ds_%d.parquet", i))
-		if err := w.minio.DownloadToFile(ctx, ds.StoragePath, localPath); err != nil {
-			return nil, fmt.Errorf("download dataset %s: %w", ds.Name, err)
-		}
-	}
-
 	// Open DuckDB in-memory
 	duckDB, err := sql.Open("duckdb", "")
 	if err != nil {
@@ -60,10 +55,16 @@ func (w *TransformWriter) Execute(ctx context.Context, msg *domain.TransformJobM
 	}
 	defer duckDB.Close()
 
-	// Register each dataset as a VIEW
-	for i, ds := range datasets {
-		localPath := filepath.Join(tmpDir, fmt.Sprintf("ds_%d.parquet", i))
-		viewSQL := fmt.Sprintf(`CREATE VIEW "%s" AS SELECT * FROM read_parquet('%s')`, ds.Name, localPath)
+	// Configure httpfs for direct S3/MinIO reads
+	s3Cfg := w.minio.S3Config()
+	if err := storage.ConfigureDuckDBHTTPFS(ctx, duckDB, s3Cfg); err != nil {
+		return nil, fmt.Errorf("configure httpfs: %w", err)
+	}
+
+	// Register each dataset as a VIEW reading directly from S3
+	for _, ds := range datasets {
+		uri := storage.S3ParquetURI(s3Cfg.Bucket, ds.StoragePath)
+		viewSQL := fmt.Sprintf(`CREATE VIEW "%s" AS SELECT * FROM read_parquet('%s')`, ds.Name, uri)
 		if _, err := duckDB.ExecContext(ctx, viewSQL); err != nil {
 			return nil, fmt.Errorf("create view %s: %w", ds.Name, err)
 		}


### PR DESCRIPTION
## Summary
- DuckDB の `httpfs` 拡張を使い、データセット Parquet ファイルを MinIO/S3 から直接読み取るように変更
- ローカルへのファイルダウンロード＋一時ディレクトリ管理を削除し、I/O オーバーヘッドを削減
- API 側 (validate/preview) と Worker 側 (transform 実行) の両方に適用

## Test plan
- [ ] `make up && make health` でサービス起動確認
- [ ] Transform job の validate / preview が正常動作すること
- [ ] Transform job の実行 (Worker) が正常に Parquet を生成すること
- [ ] `make e2e-cli` で既存 E2E テストが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)