### PR TITLE
feat: implement Google Sheets import worker pipeline (#112)

### DIFF
--- a/apps/golang/backend/cmd/api/main.go
+++ b/apps/golang/backend/cmd/api/main.go
@@ -186,7 +186,7 @@ func main() {
 		datasetRepo, minioClient, jobService, moduleTypeRepo,
 		jobRunRepo, jobVersionRepo, jobModuleRepo, transformQueue,
 	)
-	importJobService := usecase.NewImportJobService(jobService, moduleTypeRepo, jobVersionRepo, jobModuleRepo)
+	importJobService := usecase.NewImportJobService(jobService, jobRunService, moduleTypeRepo, jobVersionRepo, jobModuleRepo)
 
 	// Handlers
 	healthH := handler.NewHealthHandler(sqlDB)

--- a/apps/golang/backend/cmd/worker/main.go
+++ b/apps/golang/backend/cmd/worker/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"os"
 	"os/signal"
 	"syscall"
 	"time"
@@ -89,12 +90,29 @@ func main() {
 
 	go transformConsumer.Run(ctx)
 
+	// Credential + Connection (for import jobs)
+	credentialRepo := db.NewCredentialRepo(sqlDB)
+	connectionRepo := db.NewConnectionRepo(sqlDB)
+	credentialService := usecase.NewCredentialService(
+		credentialRepo,
+		usecase.GoogleCredentialOAuthConfig{
+			ClientID:     os.Getenv("GOOGLE_OAUTH_CLIENT_ID"),
+			ClientSecret: os.Getenv("GOOGLE_OAUTH_CLIENT_SECRET"),
+		},
+		os.Getenv("JWT_SECRET"),
+	)
+
+	// Sheets import writer
+	sheetsImportWriter := worker.NewSheetsImportWriter(minioClient, datasetRepo)
+
 	// Job Run poller + consumer (generic job execution)
 	jobRunQueue := queue.NewJobRunQueue(valkeyClient)
 	jobRunMetrics := observability.NewJobRunMetrics()
 	jobRunPoller := worker.NewJobRunPoller(jobRunRepo, jobRunQueue, jobRunMetrics, 5*time.Second)
 	jobRunConsumer := worker.NewJobRunConsumer(
-		jobRunQueue, jobRunRepo, transformWriter, jobRunMetrics, meteringService,
+		jobRunQueue, jobRunRepo, transformWriter,
+		sheetsImportWriter, credentialService, connectionRepo,
+		jobRunMetrics, meteringService,
 	)
 
 	go jobRunPoller.Run(ctx)

--- a/apps/golang/backend/handler/import_job.go
+++ b/apps/golang/backend/handler/import_job.go
@@ -46,15 +46,20 @@ func (h *ImportJobHandler) CreateJob(w http.ResponseWriter, r *http.Request) {
 	if req.Range != nil {
 		rangeStr = *req.Range
 	}
+	execution := "save_only"
+	if req.Execution != nil {
+		execution = string(*req.Execution)
+	}
 
 	input := usecase.CreateImportJobInput{
-		Name:           req.Name,
-		Slug:           req.Slug,
-		Description:    desc,
-		ConnectionID:   req.ConnectionId,
-		SpreadsheetID:  req.SpreadsheetId,
-		SheetName:      sheetName,
-		Range:          rangeStr,
+		Name:          req.Name,
+		Slug:          req.Slug,
+		Description:   desc,
+		ConnectionID:  req.ConnectionId,
+		SpreadsheetID: req.SpreadsheetId,
+		SheetName:     sheetName,
+		Range:         rangeStr,
+		Execution:     execution,
 	}
 
 	result, err := h.importJob.CreateImportJob(r.Context(), input)
@@ -63,8 +68,14 @@ func (h *ImportJobHandler) CreateJob(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusCreated, openapi.CreateImportJobResponse{
+	resp := openapi.CreateImportJobResponse{
 		Job:     toOpenAPIJob(result.Job),
 		Version: toOpenAPIJobVersion(result.Version),
-	})
+	}
+	if result.JobRun != nil {
+		jr := toOpenAPIJobRun(result.JobRun)
+		resp.JobRun = &jr
+	}
+
+	writeJSON(w, http.StatusCreated, resp)
 }

--- a/apps/golang/backend/internal/connector/definitions/sources/google-sheets.json
+++ b/apps/golang/backend/internal/connector/definitions/sources/google-sheets.json
@@ -7,19 +7,6 @@
   "x-credential-provider": "google",
   "spec": {
     "type": "object",
-    "properties": {
-      "spreadsheet_id": {
-        "type": "string",
-        "title": "Spreadsheet ID",
-        "description": "The ID from the spreadsheet URL (e.g. https://docs.google.com/spreadsheets/d/{ID}/edit)",
-        "x-order": 1
-      },
-      "sheet_name": {
-        "type": "string",
-        "title": "Sheet Name",
-        "description": "Specific sheet tab name. If empty, the first sheet is used.",
-        "x-order": 2
-      }
-    }
+    "properties": {}
   }
 }

--- a/apps/golang/backend/internal/connector/testers/google_sheets.go
+++ b/apps/golang/backend/internal/connector/testers/google_sheets.go
@@ -2,7 +2,6 @@ package testers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,11 +9,8 @@ import (
 	"github.com/user/micro-dp/internal/connector"
 )
 
-type googleSheetsConfig struct {
-	SpreadsheetID string `json:"spreadsheet_id"`
-}
-
-// GoogleSheetsTester tests connectivity to a Google Spreadsheet.
+// GoogleSheetsTester tests connectivity by verifying the OAuth credential
+// against the Google Sheets API.
 type GoogleSheetsTester struct{}
 
 func NewGoogleSheetsTester() *GoogleSheetsTester {
@@ -22,18 +18,14 @@ func NewGoogleSheetsTester() *GoogleSheetsTester {
 }
 
 func (t *GoogleSheetsTester) Test(ctx context.Context, configJSON string, accessToken string) *connector.TestResult {
-	var cfg googleSheetsConfig
-	if err := json.Unmarshal([]byte(configJSON), &cfg); err != nil {
-		return &connector.TestResult{OK: false, Code: "invalid_config", Message: "invalid config JSON"}
-	}
-	if cfg.SpreadsheetID == "" {
-		return &connector.TestResult{OK: false, Code: "invalid_config", Message: "spreadsheet_id is required"}
-	}
 	if accessToken == "" {
 		return &connector.TestResult{OK: false, Code: "unauthorized", Message: "no access token available"}
 	}
 
-	url := fmt.Sprintf("https://sheets.googleapis.com/v4/spreadsheets/%s?fields=properties.title", cfg.SpreadsheetID)
+	// Verify the token by calling the Sheets API with a minimal request.
+	// Getting spreadsheet "" returns 404 if the token is valid, 401 if not.
+	// We use a lightweight endpoint that only requires spreadsheets.readonly scope.
+	url := "https://sheets.googleapis.com/v4/spreadsheets/__test_connectivity__?fields=properties.title"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return &connector.TestResult{OK: false, Code: "invalid_config", Message: err.Error()}
@@ -47,15 +39,14 @@ func (t *GoogleSheetsTester) Test(ctx context.Context, configJSON string, access
 	defer resp.Body.Close()
 	io.Copy(io.Discard, resp.Body)
 
-	switch {
-	case resp.StatusCode == http.StatusOK:
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusNotFound:
+		// 404 = token is valid but spreadsheet doesn't exist (expected)
 		return &connector.TestResult{OK: true, Code: "ok", Message: "connected successfully"}
-	case resp.StatusCode == http.StatusUnauthorized:
+	case http.StatusUnauthorized:
 		return &connector.TestResult{OK: false, Code: "unauthorized", Message: "access token is invalid or expired"}
-	case resp.StatusCode == http.StatusForbidden:
-		return &connector.TestResult{OK: false, Code: "forbidden", Message: "insufficient permissions to access this spreadsheet"}
-	case resp.StatusCode == http.StatusNotFound:
-		return &connector.TestResult{OK: false, Code: "not_found", Message: "spreadsheet not found"}
+	case http.StatusForbidden:
+		return &connector.TestResult{OK: false, Code: "forbidden", Message: "insufficient permissions"}
 	default:
 		return &connector.TestResult{OK: false, Code: "invalid_config", Message: fmt.Sprintf("unexpected status %d", resp.StatusCode)}
 	}

--- a/apps/golang/backend/internal/openapi/types.gen.go
+++ b/apps/golang/backend/internal/openapi/types.gen.go
@@ -40,6 +40,12 @@ const (
 	HealthResponseStatusOk       HealthResponseStatus = "ok"
 )
 
+// Defines values for ImportExecution.
+const (
+	ImportExecutionImmediate ImportExecution = "immediate"
+	ImportExecutionSaveOnly  ImportExecution = "save_only"
+)
+
 // Defines values for IngestEventResponseStatus.
 const (
 	IngestEventResponseStatusAccepted IngestEventResponseStatus = "accepted"
@@ -119,9 +125,9 @@ const (
 
 // Defines values for TransformExecution.
 const (
-	Immediate TransformExecution = "immediate"
-	SaveOnly  TransformExecution = "save_only"
-	Scheduled TransformExecution = "scheduled"
+	TransformExecutionImmediate TransformExecution = "immediate"
+	TransformExecutionSaveOnly  TransformExecution = "save_only"
+	TransformExecutionScheduled TransformExecution = "scheduled"
 )
 
 // Defines values for UploadStatus.
@@ -243,18 +249,20 @@ type CreateEdgeInput struct {
 
 // CreateImportJobRequest defines model for CreateImportJobRequest.
 type CreateImportJobRequest struct {
-	ConnectionId  string  `json:"connection_id"`
-	Description   *string `json:"description,omitempty"`
-	Name          string  `json:"name"`
-	Range         *string `json:"range,omitempty"`
-	SheetName     *string `json:"sheet_name,omitempty"`
-	Slug          string  `json:"slug"`
-	SpreadsheetId string  `json:"spreadsheet_id"`
+	ConnectionId  string           `json:"connection_id"`
+	Description   *string          `json:"description,omitempty"`
+	Execution     *ImportExecution `json:"execution,omitempty"`
+	Name          string           `json:"name"`
+	Range         *string          `json:"range,omitempty"`
+	SheetName     *string          `json:"sheet_name,omitempty"`
+	Slug          string           `json:"slug"`
+	SpreadsheetId string           `json:"spreadsheet_id"`
 }
 
 // CreateImportJobResponse defines model for CreateImportJobResponse.
 type CreateImportJobResponse struct {
 	Job     Job        `json:"job"`
+	JobRun  *JobRun    `json:"job_run,omitempty"`
 	Version JobVersion `json:"version"`
 }
 
@@ -417,6 +425,9 @@ type HealthResponse struct {
 
 // HealthResponseStatus defines model for HealthResponse.Status.
 type HealthResponseStatus string
+
+// ImportExecution defines model for ImportExecution.
+type ImportExecution string
 
 // IngestEventRequest defines model for IngestEventRequest.
 type IngestEventRequest struct {

--- a/apps/golang/backend/usecase/import_job.go
+++ b/apps/golang/backend/usecase/import_job.go
@@ -11,6 +11,7 @@ import (
 
 type ImportJobService struct {
 	jobs        *JobService
+	jobRuns     *JobRunService
 	moduleTypes domain.ModuleTypeRepository
 	versions    domain.JobVersionRepository
 	modules     domain.JobModuleRepository
@@ -18,12 +19,14 @@ type ImportJobService struct {
 
 func NewImportJobService(
 	jobs *JobService,
+	jobRuns *JobRunService,
 	moduleTypes domain.ModuleTypeRepository,
 	versions domain.JobVersionRepository,
 	modules domain.JobModuleRepository,
 ) *ImportJobService {
 	return &ImportJobService{
 		jobs:        jobs,
+		jobRuns:     jobRuns,
 		moduleTypes: moduleTypes,
 		versions:    versions,
 		modules:     modules,
@@ -38,11 +41,13 @@ type CreateImportJobInput struct {
 	SpreadsheetID string
 	SheetName     string
 	Range         string
+	Execution     string
 }
 
 type CreateImportJobResult struct {
 	Job     *domain.Job
 	Version *domain.JobVersion
+	JobRun  *domain.JobRun
 }
 
 func (s *ImportJobService) CreateImportJob(ctx context.Context, input CreateImportJobInput) (*CreateImportJobResult, error) {
@@ -119,8 +124,29 @@ func (s *ImportJobService) CreateImportJob(ctx context.Context, input CreateImpo
 		return nil, fmt.Errorf("create module: %w", err)
 	}
 
-	return &CreateImportJobResult{
+	out := &CreateImportJobResult{
 		Job:     job,
 		Version: version,
-	}, nil
+	}
+
+	execution := input.Execution
+	if execution == "" {
+		execution = "save_only"
+	}
+
+	if execution == "immediate" {
+		// Auto-publish the version
+		if _, err := s.jobs.PublishVersion(ctx, job.ID, version.ID); err != nil {
+			return nil, fmt.Errorf("publish version: %w", err)
+		}
+
+		// Create job run (JobRunService builds RunSnapshot and sets status=queued)
+		jr, err := s.jobRuns.Create(ctx, job.ID, &version.ID)
+		if err != nil {
+			return nil, fmt.Errorf("create job run: %w", err)
+		}
+		out.JobRun = jr
+	}
+
+	return out, nil
 }

--- a/apps/golang/backend/worker/job_run_consumer.go
+++ b/apps/golang/backend/worker/job_run_consumer.go
@@ -17,6 +17,9 @@ type JobRunConsumer struct {
 	queue           domain.JobRunQueue
 	jobRuns         domain.JobRunRepository
 	transformWriter *TransformWriter
+	sheetsWriter    *SheetsImportWriter
+	credentials     *usecase.CredentialService
+	connections     domain.ConnectionRepository
 	metrics         *observability.JobRunMetrics
 	metering        *usecase.MeteringService
 }
@@ -25,6 +28,9 @@ func NewJobRunConsumer(
 	queue domain.JobRunQueue,
 	jobRuns domain.JobRunRepository,
 	transformWriter *TransformWriter,
+	sheetsWriter *SheetsImportWriter,
+	credentials *usecase.CredentialService,
+	connections domain.ConnectionRepository,
 	metrics *observability.JobRunMetrics,
 	metering *usecase.MeteringService,
 ) *JobRunConsumer {
@@ -32,6 +38,9 @@ func NewJobRunConsumer(
 		queue:           queue,
 		jobRuns:         jobRuns,
 		transformWriter: transformWriter,
+		sheetsWriter:    sheetsWriter,
+		credentials:     credentials,
+		connections:     connections,
 		metrics:         metrics,
 		metering:        metering,
 	}
@@ -113,6 +122,8 @@ func (c *JobRunConsumer) processMessage(ctx context.Context, msg *domain.JobRunM
 	switch snapshot.JobKind {
 	case domain.JobKindTransform:
 		execErr = c.executeTransform(ctx, msg, &snapshot)
+	case domain.JobKindImport:
+		execErr = c.executeImport(ctx, msg, &snapshot)
 	default:
 		execErr = fmt.Errorf("executor not implemented for kind: %s", snapshot.JobKind)
 	}
@@ -187,6 +198,70 @@ func (c *JobRunConsumer) failJobRun(ctx context.Context, msg *domain.JobRunMessa
 		log.Printf("job_run_consumer: update failed error job_run_id=%s: %v", msg.JobRunID, err)
 	}
 	c.enqueueDLQ(ctx, msg, errMsg)
+}
+
+func (c *JobRunConsumer) executeImport(ctx context.Context, msg *domain.JobRunMessage, snapshot *domain.RunSnapshot) error {
+	// Find source module in snapshot
+	var sourceModule *domain.RunSnapshotModule
+	for i := range snapshot.Modules {
+		if snapshot.Modules[i].Category == domain.ModuleTypeCategorySource {
+			sourceModule = &snapshot.Modules[i]
+			break
+		}
+	}
+	if sourceModule == nil {
+		return fmt.Errorf("no source module found in snapshot")
+	}
+
+	// Parse config_json
+	var config struct {
+		SpreadsheetID string `json:"spreadsheet_id"`
+		SheetName     string `json:"sheet_name"`
+		Range         string `json:"range"`
+	}
+	if err := json.Unmarshal([]byte(sourceModule.ConfigJSON), &config); err != nil {
+		return fmt.Errorf("parse import config: %w", err)
+	}
+	if config.SpreadsheetID == "" {
+		return fmt.Errorf("import config missing spreadsheet_id")
+	}
+
+	// Resolve connection → credential → access token
+	if sourceModule.ConnectionID == nil {
+		return fmt.Errorf("source module has no connection_id")
+	}
+	conn, err := c.connections.FindByID(ctx, msg.TenantID, *sourceModule.ConnectionID)
+	if err != nil {
+		return fmt.Errorf("find connection: %w", err)
+	}
+	if conn.CredentialID == nil {
+		return fmt.Errorf("connection has no credential_id")
+	}
+	accessToken, err := c.credentials.GetValidAccessToken(ctx, msg.TenantID, *conn.CredentialID)
+	if err != nil {
+		return fmt.Errorf("get access token: %w", err)
+	}
+
+	importMsg := &SheetsImportMessage{
+		JobRunID:      msg.JobRunID,
+		TenantID:      msg.TenantID,
+		SpreadsheetID: config.SpreadsheetID,
+		SheetName:     config.SheetName,
+		Range:         config.Range,
+		AccessToken:   accessToken,
+		JobID:         snapshot.JobID,
+		VersionID:     snapshot.VersionID,
+	}
+
+	result, err := c.sheetsWriter.Execute(ctx, importMsg)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("job_run_consumer: import completed job_run_id=%s rows=%d output=%s",
+		msg.JobRunID, result.RowCount, result.OutputKey)
+
+	return nil
 }
 
 func (c *JobRunConsumer) enqueueDLQ(ctx context.Context, msg *domain.JobRunMessage, reason string) {

--- a/apps/golang/backend/worker/sheets_import_writer.go
+++ b/apps/golang/backend/worker/sheets_import_writer.go
@@ -1,0 +1,299 @@
+package worker
+
+import (
+	"context"
+	"database/sql"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/user/micro-dp/domain"
+	"github.com/user/micro-dp/storage"
+)
+
+type SheetsImportMessage struct {
+	JobRunID      string
+	TenantID      string
+	SpreadsheetID string
+	SheetName     string
+	Range         string
+	AccessToken   string
+	JobID         string
+	VersionID     string
+}
+
+type SheetsImportResult struct {
+	RowCount  int64
+	OutputKey string
+}
+
+type SheetsImportWriter struct {
+	minio    *storage.MinIOClient
+	datasets domain.DatasetRepository
+}
+
+func NewSheetsImportWriter(minio *storage.MinIOClient, datasets domain.DatasetRepository) *SheetsImportWriter {
+	return &SheetsImportWriter{minio: minio, datasets: datasets}
+}
+
+func (w *SheetsImportWriter) Execute(ctx context.Context, msg *SheetsImportMessage) (*SheetsImportResult, error) {
+	tmpDir, err := os.MkdirTemp("", "micro-dp-sheets-import-*")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Resolve sheet name if empty
+	sheetName := msg.SheetName
+	spreadsheetTitle := ""
+	if sheetName == "" {
+		title, firstSheet, err := w.getSpreadsheetInfo(ctx, msg.AccessToken, msg.SpreadsheetID)
+		if err != nil {
+			return nil, fmt.Errorf("get spreadsheet info: %w", err)
+		}
+		sheetName = firstSheet
+		spreadsheetTitle = title
+	} else {
+		title, _, err := w.getSpreadsheetInfo(ctx, msg.AccessToken, msg.SpreadsheetID)
+		if err != nil {
+			spreadsheetTitle = msg.SpreadsheetID
+		} else {
+			spreadsheetTitle = title
+		}
+	}
+
+	// Fetch data from Sheets API
+	values, err := w.getSheetValues(ctx, msg.AccessToken, msg.SpreadsheetID, sheetName, msg.Range)
+	if err != nil {
+		return nil, fmt.Errorf("get sheet values: %w", err)
+	}
+	if len(values) == 0 {
+		return nil, fmt.Errorf("sheet returned no data")
+	}
+
+	// Write to CSV temp file
+	csvPath := filepath.Join(tmpDir, "input.csv")
+	if err := w.writeCSV(csvPath, values); err != nil {
+		return nil, fmt.Errorf("write csv: %w", err)
+	}
+
+	// DuckDB: CSV → Parquet
+	duckDB, err := sql.Open("duckdb", "")
+	if err != nil {
+		return nil, fmt.Errorf("open duckdb: %w", err)
+	}
+	defer duckDB.Close()
+
+	_, err = duckDB.ExecContext(ctx, fmt.Sprintf("CREATE TABLE imported AS SELECT * FROM read_csv('%s', header=true, auto_detect=true, delim=',', null_padding=true, ignore_errors=true)", csvPath))
+	if err != nil {
+		return nil, fmt.Errorf("read csv: %w", err)
+	}
+
+	schemaJSON, err := extractSheetsSchema(ctx, duckDB)
+	if err != nil {
+		return nil, fmt.Errorf("extract schema: %w", err)
+	}
+
+	var rowCount int64
+	if err := duckDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM imported").Scan(&rowCount); err != nil {
+		return nil, fmt.Errorf("count rows: %w", err)
+	}
+
+	parquetPath := filepath.Join(tmpDir, "output.parquet")
+	_, err = duckDB.ExecContext(ctx, fmt.Sprintf("COPY imported TO '%s' (FORMAT PARQUET)", parquetPath))
+	if err != nil {
+		return nil, fmt.Errorf("copy to parquet: %w", err)
+	}
+
+	// Upload to MinIO
+	data, err := os.ReadFile(parquetPath)
+	if err != nil {
+		return nil, fmt.Errorf("read parquet: %w", err)
+	}
+
+	now := time.Now().UTC()
+	outputKey := fmt.Sprintf("sheets_imports/%s/dt=%s/%s.parquet",
+		msg.TenantID,
+		now.Format("2006-01-02"),
+		msg.JobRunID,
+	)
+	if err := w.minio.PutParquet(ctx, outputKey, data); err != nil {
+		return nil, fmt.Errorf("upload parquet: %w", err)
+	}
+
+	// Upsert dataset
+	datasetName := fmt.Sprintf("%s - %s", spreadsheetTitle, sheetName)
+	lastUpdated := now
+	dataset := &domain.Dataset{
+		ID:            uuid.New().String(),
+		TenantID:      msg.TenantID,
+		Name:          datasetName,
+		SourceType:    domain.SourceTypeImport,
+		SchemaJSON:    &schemaJSON,
+		RowCount:      &rowCount,
+		StoragePath:   outputKey,
+		LastUpdatedAt: &lastUpdated,
+	}
+	if err := w.datasets.Upsert(ctx, dataset); err != nil {
+		return nil, fmt.Errorf("upsert dataset: %w", err)
+	}
+
+	return &SheetsImportResult{
+		RowCount:  rowCount,
+		OutputKey: outputKey,
+	}, nil
+}
+
+// getSpreadsheetInfo fetches the spreadsheet title and first sheet name.
+func (w *SheetsImportWriter) getSpreadsheetInfo(ctx context.Context, accessToken, spreadsheetID string) (title string, firstSheet string, err error) {
+	apiURL := fmt.Sprintf("https://sheets.googleapis.com/v4/spreadsheets/%s?fields=properties.title,sheets.properties.title", url.PathEscape(spreadsheetID))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", "", fmt.Errorf("sheets api returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Properties struct {
+			Title string `json:"title"`
+		} `json:"properties"`
+		Sheets []struct {
+			Properties struct {
+				Title string `json:"title"`
+			} `json:"properties"`
+		} `json:"sheets"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", "", fmt.Errorf("decode response: %w", err)
+	}
+
+	if len(result.Sheets) == 0 {
+		return "", "", fmt.Errorf("spreadsheet has no sheets")
+	}
+
+	return result.Properties.Title, result.Sheets[0].Properties.Title, nil
+}
+
+// getSheetValues fetches cell values from the Sheets API.
+func (w *SheetsImportWriter) getSheetValues(ctx context.Context, accessToken, spreadsheetID, sheetName, cellRange string) ([][]interface{}, error) {
+	rangeStr := sheetName
+	if cellRange != "" {
+		rangeStr = sheetName + "!" + cellRange
+	}
+
+	apiURL := fmt.Sprintf("https://sheets.googleapis.com/v4/spreadsheets/%s/values/%s",
+		url.PathEscape(spreadsheetID),
+		url.PathEscape(rangeStr),
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("sheets api returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		Values [][]interface{} `json:"values"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+
+	return result.Values, nil
+}
+
+// writeCSV writes the Sheets values to a CSV file. First row is treated as header.
+// Sheets API omits trailing empty cells, so rows may have fewer columns than the header.
+// This function pads all rows to match the header length.
+func (w *SheetsImportWriter) writeCSV(path string, values [][]interface{}) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	writer := csv.NewWriter(f)
+	defer writer.Flush()
+
+	// Determine max column count from header (first row)
+	numCols := 0
+	if len(values) > 0 {
+		numCols = len(values[0])
+	}
+
+	for _, row := range values {
+		record := make([]string, numCols)
+		for i := 0; i < numCols; i++ {
+			if i < len(row) {
+				record[i] = fmt.Sprintf("%v", row[i])
+			}
+			// else remains "" (empty string)
+		}
+		if err := writer.Write(record); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func extractSheetsSchema(ctx context.Context, db *sql.DB) (string, error) {
+	rows, err := db.QueryContext(ctx, "DESCRIBE imported")
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	type column struct {
+		Name string `json:"column_name"`
+		Type string `json:"column_type"`
+	}
+	var columns []column
+	for rows.Next() {
+		var name, colType string
+		var null, key, def, extra sql.NullString
+		if err := rows.Scan(&name, &colType, &null, &key, &def, &extra); err != nil {
+			return "", err
+		}
+		columns = append(columns, column{Name: name, Type: colType})
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+
+	data, err := json.Marshal(columns)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/apps/golang/e2e-cli/internal/openapi/types.gen.go
+++ b/apps/golang/e2e-cli/internal/openapi/types.gen.go
@@ -40,6 +40,12 @@ const (
 	HealthResponseStatusOk       HealthResponseStatus = "ok"
 )
 
+// Defines values for ImportExecution.
+const (
+	ImportExecutionImmediate ImportExecution = "immediate"
+	ImportExecutionSaveOnly  ImportExecution = "save_only"
+)
+
 // Defines values for IngestEventResponseStatus.
 const (
 	IngestEventResponseStatusAccepted IngestEventResponseStatus = "accepted"
@@ -119,9 +125,9 @@ const (
 
 // Defines values for TransformExecution.
 const (
-	Immediate TransformExecution = "immediate"
-	SaveOnly  TransformExecution = "save_only"
-	Scheduled TransformExecution = "scheduled"
+	TransformExecutionImmediate TransformExecution = "immediate"
+	TransformExecutionSaveOnly  TransformExecution = "save_only"
+	TransformExecutionScheduled TransformExecution = "scheduled"
 )
 
 // Defines values for UploadStatus.
@@ -243,18 +249,20 @@ type CreateEdgeInput struct {
 
 // CreateImportJobRequest defines model for CreateImportJobRequest.
 type CreateImportJobRequest struct {
-	ConnectionId  string  `json:"connection_id"`
-	Description   *string `json:"description,omitempty"`
-	Name          string  `json:"name"`
-	Range         *string `json:"range,omitempty"`
-	SheetName     *string `json:"sheet_name,omitempty"`
-	Slug          string  `json:"slug"`
-	SpreadsheetId string  `json:"spreadsheet_id"`
+	ConnectionId  string           `json:"connection_id"`
+	Description   *string          `json:"description,omitempty"`
+	Execution     *ImportExecution `json:"execution,omitempty"`
+	Name          string           `json:"name"`
+	Range         *string          `json:"range,omitempty"`
+	SheetName     *string          `json:"sheet_name,omitempty"`
+	Slug          string           `json:"slug"`
+	SpreadsheetId string           `json:"spreadsheet_id"`
 }
 
 // CreateImportJobResponse defines model for CreateImportJobResponse.
 type CreateImportJobResponse struct {
 	Job     Job        `json:"job"`
+	JobRun  *JobRun    `json:"job_run,omitempty"`
 	Version JobVersion `json:"version"`
 }
 
@@ -417,6 +425,9 @@ type HealthResponse struct {
 
 // HealthResponseStatus defines model for HealthResponse.Status.
 type HealthResponseStatus string
+
+// ImportExecution defines model for ImportExecution.
+type ImportExecution string
 
 // IngestEventRequest defines model for IngestEventRequest.
 type IngestEventRequest struct {

--- a/apps/node/web/src/app/(app)/jobs/new/import/import-job-form.tsx
+++ b/apps/node/web/src/app/(app)/jobs/new/import/import-job-form.tsx
@@ -53,6 +53,11 @@ export function ImportJobForm({
   const [sheetName, setSheetName] = useState("");
   const [range, setRange] = useState("");
 
+  // Execution
+  const [execution, setExecution] = useState<"save_only" | "immediate">(
+    "save_only"
+  );
+
   // Submit
   const [submitting, setSubmitting] = useState(false);
   const [message, setMessage] = useState("");
@@ -129,6 +134,7 @@ export function ImportJobForm({
         description: description || undefined,
         connection_id: connectionId,
         spreadsheet_id: spreadsheetId || undefined,
+        execution,
       };
       if (sheetName) body.sheet_name = sheetName;
       if (range) body.range = range;
@@ -146,8 +152,13 @@ export function ImportJobForm({
         return;
       }
       const created = data as CreateResponse;
-      setMessage("Import job created successfully!");
-      setTimeout(() => router.push(`/jobs/${created.job.id}`), 1500);
+      if (execution === "immediate") {
+        setMessage("Import job created and queued for execution!");
+        setTimeout(() => router.push("/jobs"), 1500);
+      } else {
+        setMessage("Import job created successfully!");
+        setTimeout(() => router.push(`/jobs/${created.job.id}`), 1500);
+      }
     } catch {
       setError("Creation request failed");
     } finally {
@@ -301,6 +312,45 @@ export function ImportJobForm({
           ) : null}
         </div>
       ) : null}
+
+      {/* Execution Timing */}
+      <div className="rounded-lg border p-4 space-y-4">
+        <h2 className="text-lg font-semibold">Execution</h2>
+        <div className="space-y-2">
+          <label className="flex items-center gap-3 cursor-pointer">
+            <input
+              type="radio"
+              name="execution"
+              value="save_only"
+              checked={execution === "save_only"}
+              onChange={() => setExecution("save_only")}
+              className="h-4 w-4"
+            />
+            <div>
+              <span className="font-medium">Save only</span>
+              <p className="text-sm text-muted-foreground">
+                Save the job without running it
+              </p>
+            </div>
+          </label>
+          <label className="flex items-center gap-3 cursor-pointer">
+            <input
+              type="radio"
+              name="execution"
+              value="immediate"
+              checked={execution === "immediate"}
+              onChange={() => setExecution("immediate")}
+              className="h-4 w-4"
+            />
+            <div>
+              <span className="font-medium">Run immediately</span>
+              <p className="text-sm text-muted-foreground">
+                Create and start the job right away
+              </p>
+            </div>
+          </label>
+        </div>
+      </div>
 
       {/* Submit */}
       <div className="flex gap-3">

--- a/apps/node/web/src/lib/api/generated.ts
+++ b/apps/node/web/src/lib/api/generated.ts
@@ -1528,6 +1528,8 @@ export interface components {
             title: string;
             items: components["schemas"]["SchemaItem"][];
         };
+        /** @enum {string} */
+        ImportExecution: "save_only" | "immediate";
         CreateImportJobRequest: {
             name: string;
             slug: string;
@@ -1536,10 +1538,12 @@ export interface components {
             spreadsheet_id: string;
             sheet_name?: string;
             range?: string;
+            execution?: components["schemas"]["ImportExecution"];
         };
         CreateImportJobResponse: {
             job: components["schemas"]["Job"];
             version: components["schemas"]["JobVersion"];
+            job_run?: components["schemas"]["JobRun"];
         };
     };
     responses: {

--- a/spec/openapi/v1.yaml
+++ b/spec/openapi/v1.yaml
@@ -2988,6 +2988,9 @@ components:
           items:
             $ref: "#/components/schemas/SchemaItem"
     # ---- Import Job ----
+    ImportExecution:
+      type: string
+      enum: [save_only, immediate]
     CreateImportJobRequest:
       type: object
       required: [name, slug, connection_id, spreadsheet_id]
@@ -3006,6 +3009,8 @@ components:
           type: string
         range:
           type: string
+        execution:
+          $ref: "#/components/schemas/ImportExecution"
     CreateImportJobResponse:
       type: object
       required: [job, version]
@@ -3014,3 +3019,5 @@ components:
           $ref: "#/components/schemas/Job"
         version:
           $ref: "#/components/schemas/JobVersion"
+        job_run:
+          $ref: "#/components/schemas/JobRun"


### PR DESCRIPTION
## Summary

- **Worker pipeline**: Added `SheetsImportWriter` that fetches data from Google Sheets API, converts to CSV, transforms to Parquet via DuckDB, uploads to MinIO, and upserts dataset catalog
- **Immediate execution**: Import job creation now supports "Save only" / "Run immediately" options (matching transform jobs), with auto-publish and job run creation for immediate mode
- **Connector simplification**: Removed `spreadsheet_id` and `sheet_name` from Google Sheets connector definition (moved to Import Job form); simplified tester to use Sheets API for token validation
- **CSV parsing fix**: Padded variable-length rows from Sheets API to match header column count, and used explicit DuckDB `read_csv` params to handle edge cases

## Test plan

- [ ] Create a Google Sheets connection with OAuth credential
- [ ] Test connection passes (token validation via Sheets API)
- [ ] Create an import job with "Run immediately" → verify job run is created and queued
- [ ] Verify worker processes the job: Sheets API fetch → CSV → Parquet → MinIO upload
- [ ] Check dataset is created with correct schema and row count
- [ ] Create an import job with "Save only" → verify no job run is created
- [ ] Verify multi-column spreadsheets with empty trailing cells import correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)