### PR TITLE
docs: add project board workflow and formalize operational rules

### DIFF
--- a/.claude/skills/project/SKILL.md
+++ b/.claude/skills/project/SKILL.md
@@ -14,27 +14,28 @@ GitHub Projects (micro-dp #2) のボード操作と運用ルールの参照。
 - Owner: `3106k`
 - Project number: `2`
 - URL: https://github.com/users/3106k/projects/2
+- **SSOT**: 進行管理の単一の真実源。口頭/チャット合意より Project 状態を正とする
 
 ## カラム (Status) 定義
 
-| Status | 意味 | 入る条件 | 出る条件 |
+| Status | 定義 | 入る条件 | 出る条件 |
 |--------|------|---------|---------|
-| **Todo** | 未着手、バックログ | issue 作成時のデフォルト | Ready に移動 |
-| **Ready** | 着手可能、依存なし | 仕様・依存が明確になった | 作業開始時に In Progress へ |
-| **In Progress** | 作業中 | ブランチを切って着手した | PR 作成時に Review へ |
-| **Review** | PR レビュー待ち | PR が作成された | マージ後に Done へ |
-| **Done** | 完了 | PR がマージされた | — |
-| **Blocked** | ブロック中 | 依存 issue が未完了 / 外部要因で進行不可 | ブロック解消後に元の Status へ |
+| **Todo** | 未準備 | issue 作成時のデフォルト | 仕様・依存が明確になったら Ready へ |
+| **Ready** | 依存解決済みで着手可能 | 仕様・依存が明確、OpenAPI 変更ありなら `make openapi-check` 通過済み | 作業開始時に In Progress へ |
+| **In Progress** | 実装中 | ブランチを切って着手した | PR 作成時に Review へ |
+| **Review** | PR 作成済み・レビュー待ち | PR が作成された | マージ後に Done へ |
+| **Done** | merge 完了 + Issue close | PR がマージされ issue がクローズされた | — |
+| **Blocked** | 外部要因 / 依存待ち | 依存 issue が未完了 / 外部要因で進行不可 | ブロック解消後に元の Status へ |
 
-## フィールド定義
+## フィールド定義 (全て必須)
 
 ### Priority
 
-| 値 | 意味 |
+| 値 | 定義 |
 |----|------|
-| **P0** | 最優先、他の作業を止めてでも対応 |
-| **P1** | 次のイテレーションで対応 |
-| **P2** | 余裕があれば対応 |
+| **P0** | 今スプリント必達。他の作業を止めてでも対応 |
+| **P1** | 次に着手 |
+| **P2** | 後続（依存解消後） |
 
 ### Area
 
@@ -54,28 +55,54 @@ Blocked ステータスと併用する。
 
 ## 運用ルール
 
+### 着手順
+
+1. **In Progress** の issue から着手する
+2. In Progress が空なら **Ready** の Priority 高い順に着手
+3. 依存未解決の issue は **Blocked** に移す
+
+### WIP 制限
+
+- In Progress は **最大 2 件** (API 系 1 件 + 非 API 系 1 件)
+- 3 件目を入れる前に 1 件を Review か Blocked へ移動する
+
 ### issue 作成時
 1. Status: **Todo**
 2. Priority, Area を設定
 3. 依存がある場合は DependsOn を記入
 
 ### 作業開始時
-1. Status: **Todo** → **In Progress**
+1. Status: **Todo/Ready** → **In Progress**
 2. Assignee を自分に設定
 3. ブランチを作成して作業開始
 
 ### PR 作成時
 1. Status: **In Progress** → **Review**
-2. PR 本文に `Closes #N` を含める (マージ時に自動クローズ)
+2. **1 PR = 1 Issue** を原則とする
+3. PR 本文に `Closes #N` を必須で含める (マージ時に自動クローズ)
 
 ### マージ時
-1. Status: **Review** → **Done** (自動 or 手動)
+1. Status: **Review** → **Done**
 2. DependsOn で本 issue を参照している issue の Blocked を解除
+
+### 完了条件
+
+実装 + 必要な生成/テスト + PR merge + Issue close で Done。
 
 ### ブロック発生時
 1. Status → **Blocked**
 2. DependsOn にブロック元の issue 番号を記入
 3. ブロック元が Done になったら元の Status に戻す
+
+### OpenAPI 変更時の特則
+
+- spec 更新 (`spec/openapi/v1.yaml`) を先行する
+- `make openapi-check` 通過を **Ready → In Progress の前提** にする
+
+### 緊急割り込み
+
+- P0 で In Progress に割り込み可
+- 割り込み理由を issue コメントに 1 行残す
 
 ## コマンド
 

--- a/.claude/skills/sync-main/SKILL.md
+++ b/.claude/skills/sync-main/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: sync-main
 description: Fetch and merge origin/main into the current branch
-disable-model-invocation: true
 allowed-tools: Bash, Read
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -575,25 +575,34 @@ Playwright で `browser_take_screenshot` を使用した場合、確認完了後
 
 ## GitHub Project Board
 
-プロジェクト: https://github.com/users/3106k/projects/2
+プロジェクト: https://github.com/users/3106k/projects/2 (SSOT — 進行管理の単一の真実源)
 
-### カラム (Status)
+### Status
 
-`Todo` → `Ready` → `In Progress` → `Review` → `Done`。`Blocked` は依存未解決時に使用。
+| Status | 定義 |
+|--------|------|
+| Todo | 未準備 |
+| Ready | 依存解決済みで着手可能 |
+| In Progress | 実装中 |
+| Review | PR 作成済み・レビュー待ち |
+| Done | merge 完了 + Issue close |
+| Blocked | 外部要因 / 依存待ち |
 
-### フィールド
+### フィールド (必須)
 
 | フィールド | 値 | 用途 |
 |-----------|-----|------|
-| Priority | P0 / P1 / P2 | P0=最優先, P1=次イテレーション, P2=余裕時 |
+| Priority | P0 / P1 / P2 | P0=今スプリント必達, P1=次に着手, P2=後続 |
 | Area | API / Web / Worker / E2E | 主要な変更先 |
 | DependsOn | `#N` | ブロック元 issue 番号 |
 
-### ワークフロー
+### 運用ルール
 
-- **issue 作成時**: Status=Todo, Priority・Area を設定。依存があれば DependsOn 記入
-- **作業開始時**: Status→In Progress, Assignee 設定
-- **PR 作成時**: Status→Review。PR 本文に `Closes #N` を含める
-- **マージ時**: Status→Done。ブロックしていた issue の Blocked を解除
+- **着手順**: In Progress の issue から着手。空なら Ready の Priority 高い順
+- **WIP 制限**: In Progress は最大 2 件 (API 系 1 + 非 API 系 1)。3 件目を入れる前に 1 件を Review か Blocked へ
+- **1 PR = 1 Issue**: PR 本文に `Closes #N` 必須
+- **OpenAPI 変更**: spec 更新を先行し `make openapi-check` 通過が Ready → In Progress の前提
+- **完了条件**: 実装 + 生成/テスト + PR merge + Issue close で Done
+- **緊急割り込み**: P0 で In Progress に割り込み可。理由を issue コメントに 1 行残す
 
 詳細な操作方法・field ID は `/project` スキルを参照。


### PR DESCRIPTION
## Summary
- CLAUDE.md にプロジェクトボード運用ルールを追加（SSOT 宣言、Status/Priority 定義、WIP 制限、着手順、OpenAPI 特則、緊急割り込み）
- `/project` スキルに詳細な運用ルールを反映
- `/sync-main` スキルの `disable-model-invocation` を削除し Skill ツールから呼び出し可能に

## Test plan
- [ ] CLAUDE.md のプロジェクトボードセクションに運用ルールが記載されていること
- [ ] `/project` スキルが呼び出し可能で運用ルールが参照できること
- [ ] `/sync-main` が Skill ツール経由で呼び出せること

🤖 Generated with [Claude Code](https://claude.com/claude-code)