### PR TITLE
feat(openapi): add Dashboard/Chart/Widget/TemplateRun API contracts

### DIFF
--- a/apps/golang/backend/internal/openapi/server.gen.go
+++ b/apps/golang/backend/internal/openapi/server.gen.go
@@ -65,6 +65,24 @@ type ServerInterface interface {
 	// Receive Stripe webhook events
 	// (POST /api/v1/billing/webhook)
 	BillingWebhook(w http.ResponseWriter, r *http.Request)
+	// List charts
+	// (GET /api/v1/charts)
+	ListCharts(w http.ResponseWriter, r *http.Request, params ListChartsParams)
+	// Create chart
+	// (POST /api/v1/charts)
+	CreateChart(w http.ResponseWriter, r *http.Request, params CreateChartParams)
+	// Delete chart
+	// (DELETE /api/v1/charts/{id})
+	DeleteChart(w http.ResponseWriter, r *http.Request, id string, params DeleteChartParams)
+	// Get chart
+	// (GET /api/v1/charts/{id})
+	GetChart(w http.ResponseWriter, r *http.Request, id string, params GetChartParams)
+	// Update chart
+	// (PUT /api/v1/charts/{id})
+	UpdateChart(w http.ResponseWriter, r *http.Request, id string, params UpdateChartParams)
+	// Get chart data
+	// (GET /api/v1/charts/{id}/data)
+	GetChartData(w http.ResponseWriter, r *http.Request, id string, params GetChartDataParams)
 	// List connections
 	// (GET /api/v1/connections)
 	ListConnections(w http.ResponseWriter, r *http.Request, params ListConnectionsParams)
@@ -104,6 +122,30 @@ type ServerInterface interface {
 	// Delete credential
 	// (DELETE /api/v1/credentials/{id})
 	DeleteCredential(w http.ResponseWriter, r *http.Request, id string, params DeleteCredentialParams)
+	// List dashboards
+	// (GET /api/v1/dashboards)
+	ListDashboards(w http.ResponseWriter, r *http.Request, params ListDashboardsParams)
+	// Create dashboard
+	// (POST /api/v1/dashboards)
+	CreateDashboard(w http.ResponseWriter, r *http.Request, params CreateDashboardParams)
+	// List dashboard widgets
+	// (GET /api/v1/dashboards/{dashboard_id}/widgets)
+	ListDashboardWidgets(w http.ResponseWriter, r *http.Request, dashboardId string, params ListDashboardWidgetsParams)
+	// Create dashboard widget
+	// (POST /api/v1/dashboards/{dashboard_id}/widgets)
+	CreateDashboardWidget(w http.ResponseWriter, r *http.Request, dashboardId string, params CreateDashboardWidgetParams)
+	// Delete dashboard widget
+	// (DELETE /api/v1/dashboards/{dashboard_id}/widgets/{widget_id})
+	DeleteDashboardWidget(w http.ResponseWriter, r *http.Request, dashboardId string, widgetId string, params DeleteDashboardWidgetParams)
+	// Delete dashboard
+	// (DELETE /api/v1/dashboards/{id})
+	DeleteDashboard(w http.ResponseWriter, r *http.Request, id string, params DeleteDashboardParams)
+	// Get dashboard
+	// (GET /api/v1/dashboards/{id})
+	GetDashboard(w http.ResponseWriter, r *http.Request, id string, params GetDashboardParams)
+	// Update dashboard
+	// (PUT /api/v1/dashboards/{id})
+	UpdateDashboard(w http.ResponseWriter, r *http.Request, id string, params UpdateDashboardParams)
 	// List datasets
 	// (GET /api/v1/datasets)
 	ListDatasets(w http.ResponseWriter, r *http.Request, params ListDatasetsParams)
@@ -188,6 +230,15 @@ type ServerInterface interface {
 	// Get current tenant plan
 	// (GET /api/v1/plan)
 	GetTenantPlan(w http.ResponseWriter, r *http.Request, params GetTenantPlanParams)
+	// List template runs
+	// (GET /api/v1/template_runs)
+	ListTemplateRuns(w http.ResponseWriter, r *http.Request, params ListTemplateRunsParams)
+	// Create template run
+	// (POST /api/v1/template_runs)
+	CreateTemplateRun(w http.ResponseWriter, r *http.Request, params CreateTemplateRunParams)
+	// Get template run
+	// (GET /api/v1/template_runs/{id})
+	GetTemplateRun(w http.ResponseWriter, r *http.Request, id string, params GetTemplateRunParams)
 	// Create invitation
 	// (POST /api/v1/tenants/current/invitations)
 	CreateInvitation(w http.ResponseWriter, r *http.Request, params CreateInvitationParams)
@@ -674,6 +725,366 @@ func (siw *ServerInterfaceWrapper) BillingWebhook(w http.ResponseWriter, r *http
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.BillingWebhook(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListCharts operation middleware
+func (siw *ServerInterfaceWrapper) ListCharts(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListChartsParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListCharts(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateChart operation middleware
+func (siw *ServerInterfaceWrapper) CreateChart(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params CreateChartParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateChart(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteChart operation middleware
+func (siw *ServerInterfaceWrapper) DeleteChart(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params DeleteChartParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteChart(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetChart operation middleware
+func (siw *ServerInterfaceWrapper) GetChart(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetChartParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetChart(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateChart operation middleware
+func (siw *ServerInterfaceWrapper) UpdateChart(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params UpdateChartParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateChart(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetChartData operation middleware
+func (siw *ServerInterfaceWrapper) GetChartData(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetChartDataParams
+
+	// ------------- Optional query parameter "period" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "period", r.URL.Query(), &params.Period)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "period", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "start_date" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "start_date", r.URL.Query(), &params.StartDate)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "start_date", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "end_date" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "end_date", r.URL.Query(), &params.EndDate)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "end_date", Err: err})
+		return
+	}
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetChartData(w, r, id, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1393,6 +1804,469 @@ func (siw *ServerInterfaceWrapper) DeleteCredential(w http.ResponseWriter, r *ht
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.DeleteCredential(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListDashboards operation middleware
+func (siw *ServerInterfaceWrapper) ListDashboards(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListDashboardsParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListDashboards(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateDashboard operation middleware
+func (siw *ServerInterfaceWrapper) CreateDashboard(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params CreateDashboardParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateDashboard(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListDashboardWidgets operation middleware
+func (siw *ServerInterfaceWrapper) ListDashboardWidgets(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "dashboard_id" -------------
+	var dashboardId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "dashboard_id", r.PathValue("dashboard_id"), &dashboardId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "dashboard_id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListDashboardWidgetsParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListDashboardWidgets(w, r, dashboardId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateDashboardWidget operation middleware
+func (siw *ServerInterfaceWrapper) CreateDashboardWidget(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "dashboard_id" -------------
+	var dashboardId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "dashboard_id", r.PathValue("dashboard_id"), &dashboardId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "dashboard_id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params CreateDashboardWidgetParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateDashboardWidget(w, r, dashboardId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteDashboardWidget operation middleware
+func (siw *ServerInterfaceWrapper) DeleteDashboardWidget(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "dashboard_id" -------------
+	var dashboardId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "dashboard_id", r.PathValue("dashboard_id"), &dashboardId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "dashboard_id", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "widget_id" -------------
+	var widgetId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "widget_id", r.PathValue("widget_id"), &widgetId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "widget_id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params DeleteDashboardWidgetParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteDashboardWidget(w, r, dashboardId, widgetId, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// DeleteDashboard operation middleware
+func (siw *ServerInterfaceWrapper) DeleteDashboard(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params DeleteDashboardParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteDashboard(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetDashboard operation middleware
+func (siw *ServerInterfaceWrapper) GetDashboard(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetDashboardParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetDashboard(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// UpdateDashboard operation middleware
+func (siw *ServerInterfaceWrapper) UpdateDashboard(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params UpdateDashboardParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateDashboard(w, r, id, params)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -3047,6 +3921,165 @@ func (siw *ServerInterfaceWrapper) GetTenantPlan(w http.ResponseWriter, r *http.
 	handler.ServeHTTP(w, r)
 }
 
+// ListTemplateRuns operation middleware
+func (siw *ServerInterfaceWrapper) ListTemplateRuns(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListTemplateRunsParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListTemplateRuns(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateTemplateRun operation middleware
+func (siw *ServerInterfaceWrapper) CreateTemplateRun(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params CreateTemplateRunParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateTemplateRun(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetTemplateRun operation middleware
+func (siw *ServerInterfaceWrapper) GetTemplateRun(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", r.PathValue("id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetTemplateRunParams
+
+	headers := r.Header
+
+	// ------------- Required header parameter "X-Tenant-ID" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("X-Tenant-ID")]; found {
+		var XTenantID XTenantID
+		n := len(valueList)
+		if n != 1 {
+			siw.ErrorHandlerFunc(w, r, &TooManyValuesForParamError{ParamName: "X-Tenant-ID", Count: n})
+			return
+		}
+
+		err = runtime.BindStyledParameterWithOptions("simple", "X-Tenant-ID", valueList[0], &XTenantID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationHeader, Explode: false, Required: true})
+		if err != nil {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "X-Tenant-ID", Err: err})
+			return
+		}
+
+		params.XTenantID = XTenantID
+
+	} else {
+		err := fmt.Errorf("Header parameter X-Tenant-ID is required, but not found")
+		siw.ErrorHandlerFunc(w, r, &RequiredHeaderError{ParamName: "X-Tenant-ID", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetTemplateRun(w, r, id, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // CreateInvitation operation middleware
 func (siw *ServerInterfaceWrapper) CreateInvitation(w http.ResponseWriter, r *http.Request) {
 
@@ -3755,6 +4788,12 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/billing/portal-session", wrapper.CreateBillingPortalSession)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/billing/subscription", wrapper.GetBillingSubscription)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/billing/webhook", wrapper.BillingWebhook)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/charts", wrapper.ListCharts)
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1/charts", wrapper.CreateChart)
+	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/charts/{id}", wrapper.DeleteChart)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/charts/{id}", wrapper.GetChart)
+	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/charts/{id}", wrapper.UpdateChart)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/charts/{id}/data", wrapper.GetChartData)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/connections", wrapper.ListConnections)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/connections", wrapper.CreateConnection)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/connections/test", wrapper.TestConnection)
@@ -3768,6 +4807,14 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/credentials/google/callback", wrapper.GoogleCredentialCallback)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/credentials/google/start", wrapper.StartGoogleCredentialOAuth)
 	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/credentials/{id}", wrapper.DeleteCredential)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/dashboards", wrapper.ListDashboards)
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1/dashboards", wrapper.CreateDashboard)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/dashboards/{dashboard_id}/widgets", wrapper.ListDashboardWidgets)
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1/dashboards/{dashboard_id}/widgets", wrapper.CreateDashboardWidget)
+	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/dashboards/{dashboard_id}/widgets/{widget_id}", wrapper.DeleteDashboardWidget)
+	m.HandleFunc("DELETE "+options.BaseURL+"/api/v1/dashboards/{id}", wrapper.DeleteDashboard)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/dashboards/{id}", wrapper.GetDashboard)
+	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/dashboards/{id}", wrapper.UpdateDashboard)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/datasets", wrapper.ListDatasets)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/datasets/{id}", wrapper.GetDataset)
 	m.HandleFunc("PATCH "+options.BaseURL+"/api/v1/datasets/{id}/columns", wrapper.UpdateDatasetColumns)
@@ -3796,6 +4843,9 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/module_types/{id}/schemas", wrapper.ListModuleTypeSchemas)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/module_types/{id}/schemas", wrapper.CreateModuleTypeSchema)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/plan", wrapper.GetTenantPlan)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/template_runs", wrapper.ListTemplateRuns)
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1/template_runs", wrapper.CreateTemplateRun)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/template_runs/{id}", wrapper.GetTemplateRun)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/tenants/current/invitations", wrapper.CreateInvitation)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/tenants/current/invitations/{token}/accept", wrapper.AcceptInvitation)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/tenants/current/members", wrapper.ListTenantMembers)
@@ -4479,6 +5529,223 @@ func (response BillingWebhook500JSONResponse) VisitBillingWebhookResponse(w http
 	return json.NewEncoder(w).Encode(response)
 }
 
+type ListChartsRequestObject struct {
+	Params ListChartsParams
+}
+
+type ListChartsResponseObject interface {
+	VisitListChartsResponse(w http.ResponseWriter) error
+}
+
+type ListCharts200JSONResponse struct {
+	Items []Chart `json:"items"`
+}
+
+func (response ListCharts200JSONResponse) VisitListChartsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListCharts401JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response ListCharts401JSONResponse) VisitListChartsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateChartRequestObject struct {
+	Params CreateChartParams
+	Body   *CreateChartJSONRequestBody
+}
+
+type CreateChartResponseObject interface {
+	VisitCreateChartResponse(w http.ResponseWriter) error
+}
+
+type CreateChart201JSONResponse Chart
+
+func (response CreateChart201JSONResponse) VisitCreateChartResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateChart400JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response CreateChart400JSONResponse) VisitCreateChartResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateChart401JSONResponse ErrorResponse
+
+func (response CreateChart401JSONResponse) VisitCreateChartResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteChartRequestObject struct {
+	Id     string `json:"id"`
+	Params DeleteChartParams
+}
+
+type DeleteChartResponseObject interface {
+	VisitDeleteChartResponse(w http.ResponseWriter) error
+}
+
+type DeleteChart204Response struct {
+}
+
+func (response DeleteChart204Response) VisitDeleteChartResponse(w http.ResponseWriter) error {
+	w.WriteHeader(204)
+	return nil
+}
+
+type DeleteChart401JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response DeleteChart401JSONResponse) VisitDeleteChartResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteChart404JSONResponse ErrorResponse
+
+func (response DeleteChart404JSONResponse) VisitDeleteChartResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetChartRequestObject struct {
+	Id     string `json:"id"`
+	Params GetChartParams
+}
+
+type GetChartResponseObject interface {
+	VisitGetChartResponse(w http.ResponseWriter) error
+}
+
+type GetChart200JSONResponse Chart
+
+func (response GetChart200JSONResponse) VisitGetChartResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetChart401JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response GetChart401JSONResponse) VisitGetChartResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetChart404JSONResponse ErrorResponse
+
+func (response GetChart404JSONResponse) VisitGetChartResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateChartRequestObject struct {
+	Id     string `json:"id"`
+	Params UpdateChartParams
+	Body   *UpdateChartJSONRequestBody
+}
+
+type UpdateChartResponseObject interface {
+	VisitUpdateChartResponse(w http.ResponseWriter) error
+}
+
+type UpdateChart200JSONResponse Chart
+
+func (response UpdateChart200JSONResponse) VisitUpdateChartResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateChart400JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response UpdateChart400JSONResponse) VisitUpdateChartResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateChart401JSONResponse ErrorResponse
+
+func (response UpdateChart401JSONResponse) VisitUpdateChartResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateChart404JSONResponse ErrorResponse
+
+func (response UpdateChart404JSONResponse) VisitUpdateChartResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetChartDataRequestObject struct {
+	Id     string `json:"id"`
+	Params GetChartDataParams
+}
+
+type GetChartDataResponseObject interface {
+	VisitGetChartDataResponse(w http.ResponseWriter) error
+}
+
+type GetChartData200JSONResponse ChartDataResponse
+
+func (response GetChartData200JSONResponse) VisitGetChartDataResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetChartData401JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response GetChartData401JSONResponse) VisitGetChartDataResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetChartData404JSONResponse ErrorResponse
+
+func (response GetChartData404JSONResponse) VisitGetChartDataResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type ListConnectionsRequestObject struct {
 	Params ListConnectionsParams
 }
@@ -4957,6 +6224,307 @@ func (response DeleteCredential401JSONResponse) VisitDeleteCredentialResponse(w 
 type DeleteCredential404JSONResponse ErrorResponse
 
 func (response DeleteCredential404JSONResponse) VisitDeleteCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListDashboardsRequestObject struct {
+	Params ListDashboardsParams
+}
+
+type ListDashboardsResponseObject interface {
+	VisitListDashboardsResponse(w http.ResponseWriter) error
+}
+
+type ListDashboards200JSONResponse struct {
+	Items []Dashboard `json:"items"`
+}
+
+func (response ListDashboards200JSONResponse) VisitListDashboardsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListDashboards401JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response ListDashboards401JSONResponse) VisitListDashboardsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateDashboardRequestObject struct {
+	Params CreateDashboardParams
+	Body   *CreateDashboardJSONRequestBody
+}
+
+type CreateDashboardResponseObject interface {
+	VisitCreateDashboardResponse(w http.ResponseWriter) error
+}
+
+type CreateDashboard201JSONResponse Dashboard
+
+func (response CreateDashboard201JSONResponse) VisitCreateDashboardResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateDashboard400JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response CreateDashboard400JSONResponse) VisitCreateDashboardResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateDashboard401JSONResponse ErrorResponse
+
+func (response CreateDashboard401JSONResponse) VisitCreateDashboardResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListDashboardWidgetsRequestObject struct {
+	DashboardId string `json:"dashboard_id"`
+	Params      ListDashboardWidgetsParams
+}
+
+type ListDashboardWidgetsResponseObject interface {
+	VisitListDashboardWidgetsResponse(w http.ResponseWriter) error
+}
+
+type ListDashboardWidgets200JSONResponse struct {
+	Items []DashboardWidget `json:"items"`
+}
+
+func (response ListDashboardWidgets200JSONResponse) VisitListDashboardWidgetsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListDashboardWidgets401JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response ListDashboardWidgets401JSONResponse) VisitListDashboardWidgetsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListDashboardWidgets404JSONResponse ErrorResponse
+
+func (response ListDashboardWidgets404JSONResponse) VisitListDashboardWidgetsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateDashboardWidgetRequestObject struct {
+	DashboardId string `json:"dashboard_id"`
+	Params      CreateDashboardWidgetParams
+	Body        *CreateDashboardWidgetJSONRequestBody
+}
+
+type CreateDashboardWidgetResponseObject interface {
+	VisitCreateDashboardWidgetResponse(w http.ResponseWriter) error
+}
+
+type CreateDashboardWidget201JSONResponse DashboardWidget
+
+func (response CreateDashboardWidget201JSONResponse) VisitCreateDashboardWidgetResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateDashboardWidget400JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response CreateDashboardWidget400JSONResponse) VisitCreateDashboardWidgetResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateDashboardWidget401JSONResponse ErrorResponse
+
+func (response CreateDashboardWidget401JSONResponse) VisitCreateDashboardWidgetResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateDashboardWidget404JSONResponse ErrorResponse
+
+func (response CreateDashboardWidget404JSONResponse) VisitCreateDashboardWidgetResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteDashboardWidgetRequestObject struct {
+	DashboardId string `json:"dashboard_id"`
+	WidgetId    string `json:"widget_id"`
+	Params      DeleteDashboardWidgetParams
+}
+
+type DeleteDashboardWidgetResponseObject interface {
+	VisitDeleteDashboardWidgetResponse(w http.ResponseWriter) error
+}
+
+type DeleteDashboardWidget204Response struct {
+}
+
+func (response DeleteDashboardWidget204Response) VisitDeleteDashboardWidgetResponse(w http.ResponseWriter) error {
+	w.WriteHeader(204)
+	return nil
+}
+
+type DeleteDashboardWidget401JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response DeleteDashboardWidget401JSONResponse) VisitDeleteDashboardWidgetResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteDashboardWidget404JSONResponse ErrorResponse
+
+func (response DeleteDashboardWidget404JSONResponse) VisitDeleteDashboardWidgetResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteDashboardRequestObject struct {
+	Id     string `json:"id"`
+	Params DeleteDashboardParams
+}
+
+type DeleteDashboardResponseObject interface {
+	VisitDeleteDashboardResponse(w http.ResponseWriter) error
+}
+
+type DeleteDashboard204Response struct {
+}
+
+func (response DeleteDashboard204Response) VisitDeleteDashboardResponse(w http.ResponseWriter) error {
+	w.WriteHeader(204)
+	return nil
+}
+
+type DeleteDashboard401JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response DeleteDashboard401JSONResponse) VisitDeleteDashboardResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteDashboard404JSONResponse ErrorResponse
+
+func (response DeleteDashboard404JSONResponse) VisitDeleteDashboardResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetDashboardRequestObject struct {
+	Id     string `json:"id"`
+	Params GetDashboardParams
+}
+
+type GetDashboardResponseObject interface {
+	VisitGetDashboardResponse(w http.ResponseWriter) error
+}
+
+type GetDashboard200JSONResponse Dashboard
+
+func (response GetDashboard200JSONResponse) VisitGetDashboardResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetDashboard401JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response GetDashboard401JSONResponse) VisitGetDashboardResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetDashboard404JSONResponse ErrorResponse
+
+func (response GetDashboard404JSONResponse) VisitGetDashboardResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateDashboardRequestObject struct {
+	Id     string `json:"id"`
+	Params UpdateDashboardParams
+	Body   *UpdateDashboardJSONRequestBody
+}
+
+type UpdateDashboardResponseObject interface {
+	VisitUpdateDashboardResponse(w http.ResponseWriter) error
+}
+
+type UpdateDashboard200JSONResponse Dashboard
+
+func (response UpdateDashboard200JSONResponse) VisitUpdateDashboardResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateDashboard400JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response UpdateDashboard400JSONResponse) VisitUpdateDashboardResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateDashboard401JSONResponse ErrorResponse
+
+func (response UpdateDashboard401JSONResponse) VisitUpdateDashboardResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateDashboard404JSONResponse ErrorResponse
+
+func (response UpdateDashboard404JSONResponse) VisitUpdateDashboardResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(404)
 
@@ -5989,6 +7557,106 @@ func (response GetTenantPlan401JSONResponse) VisitGetTenantPlanResponse(w http.R
 	return json.NewEncoder(w).Encode(response)
 }
 
+type ListTemplateRunsRequestObject struct {
+	Params ListTemplateRunsParams
+}
+
+type ListTemplateRunsResponseObject interface {
+	VisitListTemplateRunsResponse(w http.ResponseWriter) error
+}
+
+type ListTemplateRuns200JSONResponse struct {
+	Items []TemplateRun `json:"items"`
+}
+
+func (response ListTemplateRuns200JSONResponse) VisitListTemplateRunsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type ListTemplateRuns401JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response ListTemplateRuns401JSONResponse) VisitListTemplateRunsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateTemplateRunRequestObject struct {
+	Params CreateTemplateRunParams
+	Body   *CreateTemplateRunJSONRequestBody
+}
+
+type CreateTemplateRunResponseObject interface {
+	VisitCreateTemplateRunResponse(w http.ResponseWriter) error
+}
+
+type CreateTemplateRun201JSONResponse TemplateRun
+
+func (response CreateTemplateRun201JSONResponse) VisitCreateTemplateRunResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateTemplateRun400JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response CreateTemplateRun400JSONResponse) VisitCreateTemplateRunResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateTemplateRun401JSONResponse ErrorResponse
+
+func (response CreateTemplateRun401JSONResponse) VisitCreateTemplateRunResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetTemplateRunRequestObject struct {
+	Id     string `json:"id"`
+	Params GetTemplateRunParams
+}
+
+type GetTemplateRunResponseObject interface {
+	VisitGetTemplateRunResponse(w http.ResponseWriter) error
+}
+
+type GetTemplateRun200JSONResponse TemplateRun
+
+func (response GetTemplateRun200JSONResponse) VisitGetTemplateRunResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetTemplateRun401JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response GetTemplateRun401JSONResponse) VisitGetTemplateRunResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetTemplateRun404JSONResponse ErrorResponse
+
+func (response GetTemplateRun404JSONResponse) VisitGetTemplateRunResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type CreateInvitationRequestObject struct {
 	Params CreateInvitationParams
 	Body   *CreateInvitationJSONRequestBody
@@ -6522,6 +8190,24 @@ type StrictServerInterface interface {
 	// Receive Stripe webhook events
 	// (POST /api/v1/billing/webhook)
 	BillingWebhook(ctx context.Context, request BillingWebhookRequestObject) (BillingWebhookResponseObject, error)
+	// List charts
+	// (GET /api/v1/charts)
+	ListCharts(ctx context.Context, request ListChartsRequestObject) (ListChartsResponseObject, error)
+	// Create chart
+	// (POST /api/v1/charts)
+	CreateChart(ctx context.Context, request CreateChartRequestObject) (CreateChartResponseObject, error)
+	// Delete chart
+	// (DELETE /api/v1/charts/{id})
+	DeleteChart(ctx context.Context, request DeleteChartRequestObject) (DeleteChartResponseObject, error)
+	// Get chart
+	// (GET /api/v1/charts/{id})
+	GetChart(ctx context.Context, request GetChartRequestObject) (GetChartResponseObject, error)
+	// Update chart
+	// (PUT /api/v1/charts/{id})
+	UpdateChart(ctx context.Context, request UpdateChartRequestObject) (UpdateChartResponseObject, error)
+	// Get chart data
+	// (GET /api/v1/charts/{id}/data)
+	GetChartData(ctx context.Context, request GetChartDataRequestObject) (GetChartDataResponseObject, error)
 	// List connections
 	// (GET /api/v1/connections)
 	ListConnections(ctx context.Context, request ListConnectionsRequestObject) (ListConnectionsResponseObject, error)
@@ -6561,6 +8247,30 @@ type StrictServerInterface interface {
 	// Delete credential
 	// (DELETE /api/v1/credentials/{id})
 	DeleteCredential(ctx context.Context, request DeleteCredentialRequestObject) (DeleteCredentialResponseObject, error)
+	// List dashboards
+	// (GET /api/v1/dashboards)
+	ListDashboards(ctx context.Context, request ListDashboardsRequestObject) (ListDashboardsResponseObject, error)
+	// Create dashboard
+	// (POST /api/v1/dashboards)
+	CreateDashboard(ctx context.Context, request CreateDashboardRequestObject) (CreateDashboardResponseObject, error)
+	// List dashboard widgets
+	// (GET /api/v1/dashboards/{dashboard_id}/widgets)
+	ListDashboardWidgets(ctx context.Context, request ListDashboardWidgetsRequestObject) (ListDashboardWidgetsResponseObject, error)
+	// Create dashboard widget
+	// (POST /api/v1/dashboards/{dashboard_id}/widgets)
+	CreateDashboardWidget(ctx context.Context, request CreateDashboardWidgetRequestObject) (CreateDashboardWidgetResponseObject, error)
+	// Delete dashboard widget
+	// (DELETE /api/v1/dashboards/{dashboard_id}/widgets/{widget_id})
+	DeleteDashboardWidget(ctx context.Context, request DeleteDashboardWidgetRequestObject) (DeleteDashboardWidgetResponseObject, error)
+	// Delete dashboard
+	// (DELETE /api/v1/dashboards/{id})
+	DeleteDashboard(ctx context.Context, request DeleteDashboardRequestObject) (DeleteDashboardResponseObject, error)
+	// Get dashboard
+	// (GET /api/v1/dashboards/{id})
+	GetDashboard(ctx context.Context, request GetDashboardRequestObject) (GetDashboardResponseObject, error)
+	// Update dashboard
+	// (PUT /api/v1/dashboards/{id})
+	UpdateDashboard(ctx context.Context, request UpdateDashboardRequestObject) (UpdateDashboardResponseObject, error)
 	// List datasets
 	// (GET /api/v1/datasets)
 	ListDatasets(ctx context.Context, request ListDatasetsRequestObject) (ListDatasetsResponseObject, error)
@@ -6645,6 +8355,15 @@ type StrictServerInterface interface {
 	// Get current tenant plan
 	// (GET /api/v1/plan)
 	GetTenantPlan(ctx context.Context, request GetTenantPlanRequestObject) (GetTenantPlanResponseObject, error)
+	// List template runs
+	// (GET /api/v1/template_runs)
+	ListTemplateRuns(ctx context.Context, request ListTemplateRunsRequestObject) (ListTemplateRunsResponseObject, error)
+	// Create template run
+	// (POST /api/v1/template_runs)
+	CreateTemplateRun(ctx context.Context, request CreateTemplateRunRequestObject) (CreateTemplateRunResponseObject, error)
+	// Get template run
+	// (GET /api/v1/template_runs/{id})
+	GetTemplateRun(ctx context.Context, request GetTemplateRunRequestObject) (GetTemplateRunResponseObject, error)
 	// Create invitation
 	// (POST /api/v1/tenants/current/invitations)
 	CreateInvitation(ctx context.Context, request CreateInvitationRequestObject) (CreateInvitationResponseObject, error)
@@ -7180,6 +8899,180 @@ func (sh *strictHandler) BillingWebhook(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
+// ListCharts operation middleware
+func (sh *strictHandler) ListCharts(w http.ResponseWriter, r *http.Request, params ListChartsParams) {
+	var request ListChartsRequestObject
+
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListCharts(ctx, request.(ListChartsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListCharts")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListChartsResponseObject); ok {
+		if err := validResponse.VisitListChartsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// CreateChart operation middleware
+func (sh *strictHandler) CreateChart(w http.ResponseWriter, r *http.Request, params CreateChartParams) {
+	var request CreateChartRequestObject
+
+	request.Params = params
+
+	var body CreateChartJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.CreateChart(ctx, request.(CreateChartRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "CreateChart")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(CreateChartResponseObject); ok {
+		if err := validResponse.VisitCreateChartResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// DeleteChart operation middleware
+func (sh *strictHandler) DeleteChart(w http.ResponseWriter, r *http.Request, id string, params DeleteChartParams) {
+	var request DeleteChartRequestObject
+
+	request.Id = id
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.DeleteChart(ctx, request.(DeleteChartRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "DeleteChart")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(DeleteChartResponseObject); ok {
+		if err := validResponse.VisitDeleteChartResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetChart operation middleware
+func (sh *strictHandler) GetChart(w http.ResponseWriter, r *http.Request, id string, params GetChartParams) {
+	var request GetChartRequestObject
+
+	request.Id = id
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetChart(ctx, request.(GetChartRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetChart")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetChartResponseObject); ok {
+		if err := validResponse.VisitGetChartResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// UpdateChart operation middleware
+func (sh *strictHandler) UpdateChart(w http.ResponseWriter, r *http.Request, id string, params UpdateChartParams) {
+	var request UpdateChartRequestObject
+
+	request.Id = id
+	request.Params = params
+
+	var body UpdateChartJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.UpdateChart(ctx, request.(UpdateChartRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "UpdateChart")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(UpdateChartResponseObject); ok {
+		if err := validResponse.VisitUpdateChartResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetChartData operation middleware
+func (sh *strictHandler) GetChartData(w http.ResponseWriter, r *http.Request, id string, params GetChartDataParams) {
+	var request GetChartDataRequestObject
+
+	request.Id = id
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetChartData(ctx, request.(GetChartDataRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetChartData")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetChartDataResponseObject); ok {
+		if err := validResponse.VisitGetChartDataResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // ListConnections operation middleware
 func (sh *strictHandler) ListConnections(w http.ResponseWriter, r *http.Request, params ListConnectionsParams) {
 	var request ListConnectionsRequestObject
@@ -7538,6 +9431,242 @@ func (sh *strictHandler) DeleteCredential(w http.ResponseWriter, r *http.Request
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(DeleteCredentialResponseObject); ok {
 		if err := validResponse.VisitDeleteCredentialResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ListDashboards operation middleware
+func (sh *strictHandler) ListDashboards(w http.ResponseWriter, r *http.Request, params ListDashboardsParams) {
+	var request ListDashboardsRequestObject
+
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListDashboards(ctx, request.(ListDashboardsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListDashboards")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListDashboardsResponseObject); ok {
+		if err := validResponse.VisitListDashboardsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// CreateDashboard operation middleware
+func (sh *strictHandler) CreateDashboard(w http.ResponseWriter, r *http.Request, params CreateDashboardParams) {
+	var request CreateDashboardRequestObject
+
+	request.Params = params
+
+	var body CreateDashboardJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.CreateDashboard(ctx, request.(CreateDashboardRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "CreateDashboard")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(CreateDashboardResponseObject); ok {
+		if err := validResponse.VisitCreateDashboardResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ListDashboardWidgets operation middleware
+func (sh *strictHandler) ListDashboardWidgets(w http.ResponseWriter, r *http.Request, dashboardId string, params ListDashboardWidgetsParams) {
+	var request ListDashboardWidgetsRequestObject
+
+	request.DashboardId = dashboardId
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListDashboardWidgets(ctx, request.(ListDashboardWidgetsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListDashboardWidgets")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListDashboardWidgetsResponseObject); ok {
+		if err := validResponse.VisitListDashboardWidgetsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// CreateDashboardWidget operation middleware
+func (sh *strictHandler) CreateDashboardWidget(w http.ResponseWriter, r *http.Request, dashboardId string, params CreateDashboardWidgetParams) {
+	var request CreateDashboardWidgetRequestObject
+
+	request.DashboardId = dashboardId
+	request.Params = params
+
+	var body CreateDashboardWidgetJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.CreateDashboardWidget(ctx, request.(CreateDashboardWidgetRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "CreateDashboardWidget")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(CreateDashboardWidgetResponseObject); ok {
+		if err := validResponse.VisitCreateDashboardWidgetResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// DeleteDashboardWidget operation middleware
+func (sh *strictHandler) DeleteDashboardWidget(w http.ResponseWriter, r *http.Request, dashboardId string, widgetId string, params DeleteDashboardWidgetParams) {
+	var request DeleteDashboardWidgetRequestObject
+
+	request.DashboardId = dashboardId
+	request.WidgetId = widgetId
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.DeleteDashboardWidget(ctx, request.(DeleteDashboardWidgetRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "DeleteDashboardWidget")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(DeleteDashboardWidgetResponseObject); ok {
+		if err := validResponse.VisitDeleteDashboardWidgetResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// DeleteDashboard operation middleware
+func (sh *strictHandler) DeleteDashboard(w http.ResponseWriter, r *http.Request, id string, params DeleteDashboardParams) {
+	var request DeleteDashboardRequestObject
+
+	request.Id = id
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.DeleteDashboard(ctx, request.(DeleteDashboardRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "DeleteDashboard")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(DeleteDashboardResponseObject); ok {
+		if err := validResponse.VisitDeleteDashboardResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetDashboard operation middleware
+func (sh *strictHandler) GetDashboard(w http.ResponseWriter, r *http.Request, id string, params GetDashboardParams) {
+	var request GetDashboardRequestObject
+
+	request.Id = id
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetDashboard(ctx, request.(GetDashboardRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetDashboard")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetDashboardResponseObject); ok {
+		if err := validResponse.VisitGetDashboardResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// UpdateDashboard operation middleware
+func (sh *strictHandler) UpdateDashboard(w http.ResponseWriter, r *http.Request, id string, params UpdateDashboardParams) {
+	var request UpdateDashboardRequestObject
+
+	request.Id = id
+	request.Params = params
+
+	var body UpdateDashboardJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.UpdateDashboard(ctx, request.(UpdateDashboardRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "UpdateDashboard")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(UpdateDashboardResponseObject); ok {
+		if err := validResponse.VisitUpdateDashboardResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -8350,6 +10479,92 @@ func (sh *strictHandler) GetTenantPlan(w http.ResponseWriter, r *http.Request, p
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(GetTenantPlanResponseObject); ok {
 		if err := validResponse.VisitGetTenantPlanResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// ListTemplateRuns operation middleware
+func (sh *strictHandler) ListTemplateRuns(w http.ResponseWriter, r *http.Request, params ListTemplateRunsParams) {
+	var request ListTemplateRunsRequestObject
+
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.ListTemplateRuns(ctx, request.(ListTemplateRunsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "ListTemplateRuns")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(ListTemplateRunsResponseObject); ok {
+		if err := validResponse.VisitListTemplateRunsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// CreateTemplateRun operation middleware
+func (sh *strictHandler) CreateTemplateRun(w http.ResponseWriter, r *http.Request, params CreateTemplateRunParams) {
+	var request CreateTemplateRunRequestObject
+
+	request.Params = params
+
+	var body CreateTemplateRunJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.CreateTemplateRun(ctx, request.(CreateTemplateRunRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "CreateTemplateRun")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(CreateTemplateRunResponseObject); ok {
+		if err := validResponse.VisitCreateTemplateRunResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetTemplateRun operation middleware
+func (sh *strictHandler) GetTemplateRun(w http.ResponseWriter, r *http.Request, id string, params GetTemplateRunParams) {
+	var request GetTemplateRunRequestObject
+
+	request.Id = id
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetTemplateRun(ctx, request.(GetTemplateRunRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetTemplateRun")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetTemplateRunResponseObject); ok {
+		if err := validResponse.VisitGetTemplateRunResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {

--- a/apps/golang/backend/internal/openapi/types.gen.go
+++ b/apps/golang/backend/internal/openapi/types.gen.go
@@ -13,6 +13,21 @@ const (
 	BearerAuthScopes = "bearerAuth.Scopes"
 )
 
+// Defines values for ChartPeriod.
+const (
+	Custom     ChartPeriod = "custom"
+	Last30Days ChartPeriod = "last_30_days"
+	Last7Days  ChartPeriod = "last_7_days"
+	Last90Days ChartPeriod = "last_90_days"
+)
+
+// Defines values for ChartType.
+const (
+	Bar  ChartType = "bar"
+	Line ChartType = "line"
+	Pie  ChartType = "pie"
+)
+
 // Defines values for ConnectorKind.
 const (
 	ConnectorKindDestination ConnectorKind = "destination"
@@ -111,6 +126,13 @@ const (
 	View  SchemaItemType = "view"
 )
 
+// Defines values for TemplateRunStatus.
+const (
+	Failed  TemplateRunStatus = "failed"
+	Skipped TemplateRunStatus = "skipped"
+	Success TemplateRunStatus = "success"
+)
+
 // Defines values for TenantInvitationStatus.
 const (
 	TenantInvitationStatusAccepted TenantInvitationStatus = "accepted"
@@ -175,6 +197,40 @@ type BillingSubscriptionResponse struct {
 type BillingWebhookResponse struct {
 	Received bool `json:"received"`
 }
+
+// Chart defines model for Chart.
+type Chart struct {
+	ChartType  ChartType `json:"chart_type"`
+	ConfigJson *string   `json:"config_json,omitempty"`
+	CreatedAt  time.Time `json:"created_at"`
+	DatasetId  string    `json:"dataset_id"`
+	Dimension  string    `json:"dimension"`
+	Id         string    `json:"id"`
+	Measure    string    `json:"measure"`
+	Name       string    `json:"name"`
+	TenantId   string    `json:"tenant_id"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// ChartDataResponse defines model for ChartDataResponse.
+type ChartDataResponse struct {
+	ChartId  string         `json:"chart_id"`
+	Datasets []ChartDataset `json:"datasets"`
+	Labels   []string       `json:"labels"`
+	Period   ChartPeriod    `json:"period"`
+}
+
+// ChartDataset defines model for ChartDataset.
+type ChartDataset struct {
+	Data  []float32 `json:"data"`
+	Label string    `json:"label"`
+}
+
+// ChartPeriod defines model for ChartPeriod.
+type ChartPeriod string
+
+// ChartType defines model for ChartType.
+type ChartType string
 
 // ColumnStatistics defines model for ColumnStatistics.
 type ColumnStatistics struct {
@@ -248,6 +304,16 @@ type CreateBillingPortalSessionResponse struct {
 	Url string `json:"url"`
 }
 
+// CreateChartRequest defines model for CreateChartRequest.
+type CreateChartRequest struct {
+	ChartType  ChartType `json:"chart_type"`
+	ConfigJson *string   `json:"config_json,omitempty"`
+	DatasetId  string    `json:"dataset_id"`
+	Dimension  string    `json:"dimension"`
+	Measure    string    `json:"measure"`
+	Name       string    `json:"name"`
+}
+
 // CreateConnectionRequest defines model for CreateConnectionRequest.
 type CreateConnectionRequest struct {
 	ConfigJson   *string `json:"config_json,omitempty"`
@@ -255,6 +321,18 @@ type CreateConnectionRequest struct {
 	Name         string  `json:"name"`
 	SecretRef    *string `json:"secret_ref,omitempty"`
 	Type         string  `json:"type"`
+}
+
+// CreateDashboardRequest defines model for CreateDashboardRequest.
+type CreateDashboardRequest struct {
+	Description *string `json:"description,omitempty"`
+	Name        string  `json:"name"`
+}
+
+// CreateDashboardWidgetRequest defines model for CreateDashboardWidgetRequest.
+type CreateDashboardWidgetRequest struct {
+	ChartId  string `json:"chart_id"`
+	Position int    `json:"position"`
 }
 
 // CreateEdgeInput defines model for CreateEdgeInput.
@@ -343,6 +421,11 @@ type CreatePlanRequest struct {
 	Name             string `json:"name"`
 }
 
+// CreateTemplateRunRequest defines model for CreateTemplateRunRequest.
+type CreateTemplateRunRequest struct {
+	TemplateType string `json:"template_type"`
+}
+
 // CreateTransformJobRequest defines model for CreateTransformJobRequest.
 type CreateTransformJobRequest struct {
 	DatasetIds  []string            `json:"dataset_ids"`
@@ -382,6 +465,25 @@ type Credential struct {
 	TenantId      string     `json:"tenant_id"`
 	UpdatedAt     *time.Time `json:"updated_at,omitempty"`
 	UserId        string     `json:"user_id"`
+}
+
+// Dashboard defines model for Dashboard.
+type Dashboard struct {
+	CreatedAt   time.Time `json:"created_at"`
+	Description *string   `json:"description,omitempty"`
+	Id          string    `json:"id"`
+	Name        string    `json:"name"`
+	TenantId    string    `json:"tenant_id"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// DashboardWidget defines model for DashboardWidget.
+type DashboardWidget struct {
+	ChartId     string    `json:"chart_id"`
+	CreatedAt   time.Time `json:"created_at"`
+	DashboardId string    `json:"dashboard_id"`
+	Id          string    `json:"id"`
+	Position    int       `json:"position"`
 }
 
 // Dataset defines model for Dataset.
@@ -669,6 +771,20 @@ type SchemaItem struct {
 // SchemaItemType defines model for SchemaItem.Type.
 type SchemaItemType string
 
+// TemplateRun defines model for TemplateRun.
+type TemplateRun struct {
+	CreatedAt    time.Time         `json:"created_at"`
+	DashboardId  *string           `json:"dashboard_id,omitempty"`
+	Id           string            `json:"id"`
+	SkipReason   *string           `json:"skip_reason,omitempty"`
+	Status       TemplateRunStatus `json:"status"`
+	TemplateType string            `json:"template_type"`
+	TenantId     string            `json:"tenant_id"`
+}
+
+// TemplateRunStatus defines model for TemplateRunStatus.
+type TemplateRunStatus string
+
 // Tenant defines model for Tenant.
 type Tenant struct {
 	Id       string `json:"id"`
@@ -761,6 +877,16 @@ type TransformValidateResponse struct {
 	Valid   bool             `json:"valid"`
 }
 
+// UpdateChartRequest defines model for UpdateChartRequest.
+type UpdateChartRequest struct {
+	ChartType  ChartType `json:"chart_type"`
+	ConfigJson *string   `json:"config_json,omitempty"`
+	DatasetId  string    `json:"dataset_id"`
+	Dimension  string    `json:"dimension"`
+	Measure    string    `json:"measure"`
+	Name       string    `json:"name"`
+}
+
 // UpdateConnectionRequest defines model for UpdateConnectionRequest.
 type UpdateConnectionRequest struct {
 	ConfigJson   *string `json:"config_json,omitempty"`
@@ -768,6 +894,12 @@ type UpdateConnectionRequest struct {
 	Name         string  `json:"name"`
 	SecretRef    *string `json:"secret_ref,omitempty"`
 	Type         string  `json:"type"`
+}
+
+// UpdateDashboardRequest defines model for UpdateDashboardRequest.
+type UpdateDashboardRequest struct {
+	Description *string `json:"description,omitempty"`
+	Name        string  `json:"name"`
 }
 
 // UpdateDatasetColumnRequest defines model for UpdateDatasetColumnRequest.
@@ -882,6 +1014,39 @@ type GetBillingSubscriptionParams struct {
 // BillingWebhookJSONBody defines parameters for BillingWebhook.
 type BillingWebhookJSONBody map[string]interface{}
 
+// ListChartsParams defines parameters for ListCharts.
+type ListChartsParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// CreateChartParams defines parameters for CreateChart.
+type CreateChartParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// DeleteChartParams defines parameters for DeleteChart.
+type DeleteChartParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// GetChartParams defines parameters for GetChart.
+type GetChartParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// UpdateChartParams defines parameters for UpdateChart.
+type UpdateChartParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// GetChartDataParams defines parameters for GetChartData.
+type GetChartDataParams struct {
+	Period    *ChartPeriod        `form:"period,omitempty" json:"period,omitempty"`
+	StartDate *openapi_types.Date `form:"start_date,omitempty" json:"start_date,omitempty"`
+	EndDate   *openapi_types.Date `form:"end_date,omitempty" json:"end_date,omitempty"`
+	XTenantID XTenantID           `json:"X-Tenant-ID"`
+}
+
 // ListConnectionsParams defines parameters for ListConnections.
 type ListConnectionsParams struct {
 	XTenantID XTenantID `json:"X-Tenant-ID"`
@@ -948,6 +1113,46 @@ type StartGoogleCredentialOAuthParams struct {
 
 // DeleteCredentialParams defines parameters for DeleteCredential.
 type DeleteCredentialParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// ListDashboardsParams defines parameters for ListDashboards.
+type ListDashboardsParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// CreateDashboardParams defines parameters for CreateDashboard.
+type CreateDashboardParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// ListDashboardWidgetsParams defines parameters for ListDashboardWidgets.
+type ListDashboardWidgetsParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// CreateDashboardWidgetParams defines parameters for CreateDashboardWidget.
+type CreateDashboardWidgetParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// DeleteDashboardWidgetParams defines parameters for DeleteDashboardWidget.
+type DeleteDashboardWidgetParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// DeleteDashboardParams defines parameters for DeleteDashboard.
+type DeleteDashboardParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// GetDashboardParams defines parameters for GetDashboard.
+type GetDashboardParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// UpdateDashboardParams defines parameters for UpdateDashboard.
+type UpdateDashboardParams struct {
 	XTenantID XTenantID `json:"X-Tenant-ID"`
 }
 
@@ -1098,6 +1303,21 @@ type GetTenantPlanParams struct {
 	XTenantID XTenantID `json:"X-Tenant-ID"`
 }
 
+// ListTemplateRunsParams defines parameters for ListTemplateRuns.
+type ListTemplateRunsParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// CreateTemplateRunParams defines parameters for CreateTemplateRun.
+type CreateTemplateRunParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// GetTemplateRunParams defines parameters for GetTemplateRun.
+type GetTemplateRunParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
 // CreateInvitationParams defines parameters for CreateInvitation.
 type CreateInvitationParams struct {
 	XTenantID XTenantID `json:"X-Tenant-ID"`
@@ -1178,6 +1398,12 @@ type CreateBillingPortalSessionJSONRequestBody = CreateBillingPortalSessionReque
 // BillingWebhookJSONRequestBody defines body for BillingWebhook for application/json ContentType.
 type BillingWebhookJSONRequestBody BillingWebhookJSONBody
 
+// CreateChartJSONRequestBody defines body for CreateChart for application/json ContentType.
+type CreateChartJSONRequestBody = CreateChartRequest
+
+// UpdateChartJSONRequestBody defines body for UpdateChart for application/json ContentType.
+type UpdateChartJSONRequestBody = UpdateChartRequest
+
 // CreateConnectionJSONRequestBody defines body for CreateConnection for application/json ContentType.
 type CreateConnectionJSONRequestBody = CreateConnectionRequest
 
@@ -1186,6 +1412,15 @@ type TestConnectionJSONRequestBody = TestConnectionRequest
 
 // UpdateConnectionJSONRequestBody defines body for UpdateConnection for application/json ContentType.
 type UpdateConnectionJSONRequestBody = UpdateConnectionRequest
+
+// CreateDashboardJSONRequestBody defines body for CreateDashboard for application/json ContentType.
+type CreateDashboardJSONRequestBody = CreateDashboardRequest
+
+// CreateDashboardWidgetJSONRequestBody defines body for CreateDashboardWidget for application/json ContentType.
+type CreateDashboardWidgetJSONRequestBody = CreateDashboardWidgetRequest
+
+// UpdateDashboardJSONRequestBody defines body for UpdateDashboard for application/json ContentType.
+type UpdateDashboardJSONRequestBody = UpdateDashboardRequest
 
 // UpdateDatasetColumnsJSONRequestBody defines body for UpdateDatasetColumns for application/json ContentType.
 type UpdateDatasetColumnsJSONRequestBody = UpdateDatasetColumnsRequest
@@ -1213,6 +1448,9 @@ type CreateModuleTypeJSONRequestBody = CreateModuleTypeRequest
 
 // CreateModuleTypeSchemaJSONRequestBody defines body for CreateModuleTypeSchema for application/json ContentType.
 type CreateModuleTypeSchemaJSONRequestBody = CreateModuleTypeSchemaRequest
+
+// CreateTemplateRunJSONRequestBody defines body for CreateTemplateRun for application/json ContentType.
+type CreateTemplateRunJSONRequestBody = CreateTemplateRunRequest
 
 // CreateInvitationJSONRequestBody defines body for CreateInvitation for application/json ContentType.
 type CreateInvitationJSONRequestBody = CreateInvitationRequest

--- a/apps/golang/e2e-cli/internal/openapi/types.gen.go
+++ b/apps/golang/e2e-cli/internal/openapi/types.gen.go
@@ -13,6 +13,21 @@ const (
 	BearerAuthScopes = "bearerAuth.Scopes"
 )
 
+// Defines values for ChartPeriod.
+const (
+	Custom     ChartPeriod = "custom"
+	Last30Days ChartPeriod = "last_30_days"
+	Last7Days  ChartPeriod = "last_7_days"
+	Last90Days ChartPeriod = "last_90_days"
+)
+
+// Defines values for ChartType.
+const (
+	Bar  ChartType = "bar"
+	Line ChartType = "line"
+	Pie  ChartType = "pie"
+)
+
 // Defines values for ConnectorKind.
 const (
 	ConnectorKindDestination ConnectorKind = "destination"
@@ -111,6 +126,13 @@ const (
 	View  SchemaItemType = "view"
 )
 
+// Defines values for TemplateRunStatus.
+const (
+	Failed  TemplateRunStatus = "failed"
+	Skipped TemplateRunStatus = "skipped"
+	Success TemplateRunStatus = "success"
+)
+
 // Defines values for TenantInvitationStatus.
 const (
 	TenantInvitationStatusAccepted TenantInvitationStatus = "accepted"
@@ -175,6 +197,40 @@ type BillingSubscriptionResponse struct {
 type BillingWebhookResponse struct {
 	Received bool `json:"received"`
 }
+
+// Chart defines model for Chart.
+type Chart struct {
+	ChartType  ChartType `json:"chart_type"`
+	ConfigJson *string   `json:"config_json,omitempty"`
+	CreatedAt  time.Time `json:"created_at"`
+	DatasetId  string    `json:"dataset_id"`
+	Dimension  string    `json:"dimension"`
+	Id         string    `json:"id"`
+	Measure    string    `json:"measure"`
+	Name       string    `json:"name"`
+	TenantId   string    `json:"tenant_id"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}
+
+// ChartDataResponse defines model for ChartDataResponse.
+type ChartDataResponse struct {
+	ChartId  string         `json:"chart_id"`
+	Datasets []ChartDataset `json:"datasets"`
+	Labels   []string       `json:"labels"`
+	Period   ChartPeriod    `json:"period"`
+}
+
+// ChartDataset defines model for ChartDataset.
+type ChartDataset struct {
+	Data  []float32 `json:"data"`
+	Label string    `json:"label"`
+}
+
+// ChartPeriod defines model for ChartPeriod.
+type ChartPeriod string
+
+// ChartType defines model for ChartType.
+type ChartType string
 
 // ColumnStatistics defines model for ColumnStatistics.
 type ColumnStatistics struct {
@@ -248,6 +304,16 @@ type CreateBillingPortalSessionResponse struct {
 	Url string `json:"url"`
 }
 
+// CreateChartRequest defines model for CreateChartRequest.
+type CreateChartRequest struct {
+	ChartType  ChartType `json:"chart_type"`
+	ConfigJson *string   `json:"config_json,omitempty"`
+	DatasetId  string    `json:"dataset_id"`
+	Dimension  string    `json:"dimension"`
+	Measure    string    `json:"measure"`
+	Name       string    `json:"name"`
+}
+
 // CreateConnectionRequest defines model for CreateConnectionRequest.
 type CreateConnectionRequest struct {
 	ConfigJson   *string `json:"config_json,omitempty"`
@@ -255,6 +321,18 @@ type CreateConnectionRequest struct {
 	Name         string  `json:"name"`
 	SecretRef    *string `json:"secret_ref,omitempty"`
 	Type         string  `json:"type"`
+}
+
+// CreateDashboardRequest defines model for CreateDashboardRequest.
+type CreateDashboardRequest struct {
+	Description *string `json:"description,omitempty"`
+	Name        string  `json:"name"`
+}
+
+// CreateDashboardWidgetRequest defines model for CreateDashboardWidgetRequest.
+type CreateDashboardWidgetRequest struct {
+	ChartId  string `json:"chart_id"`
+	Position int    `json:"position"`
 }
 
 // CreateEdgeInput defines model for CreateEdgeInput.
@@ -343,6 +421,11 @@ type CreatePlanRequest struct {
 	Name             string `json:"name"`
 }
 
+// CreateTemplateRunRequest defines model for CreateTemplateRunRequest.
+type CreateTemplateRunRequest struct {
+	TemplateType string `json:"template_type"`
+}
+
 // CreateTransformJobRequest defines model for CreateTransformJobRequest.
 type CreateTransformJobRequest struct {
 	DatasetIds  []string            `json:"dataset_ids"`
@@ -382,6 +465,25 @@ type Credential struct {
 	TenantId      string     `json:"tenant_id"`
 	UpdatedAt     *time.Time `json:"updated_at,omitempty"`
 	UserId        string     `json:"user_id"`
+}
+
+// Dashboard defines model for Dashboard.
+type Dashboard struct {
+	CreatedAt   time.Time `json:"created_at"`
+	Description *string   `json:"description,omitempty"`
+	Id          string    `json:"id"`
+	Name        string    `json:"name"`
+	TenantId    string    `json:"tenant_id"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// DashboardWidget defines model for DashboardWidget.
+type DashboardWidget struct {
+	ChartId     string    `json:"chart_id"`
+	CreatedAt   time.Time `json:"created_at"`
+	DashboardId string    `json:"dashboard_id"`
+	Id          string    `json:"id"`
+	Position    int       `json:"position"`
 }
 
 // Dataset defines model for Dataset.
@@ -669,6 +771,20 @@ type SchemaItem struct {
 // SchemaItemType defines model for SchemaItem.Type.
 type SchemaItemType string
 
+// TemplateRun defines model for TemplateRun.
+type TemplateRun struct {
+	CreatedAt    time.Time         `json:"created_at"`
+	DashboardId  *string           `json:"dashboard_id,omitempty"`
+	Id           string            `json:"id"`
+	SkipReason   *string           `json:"skip_reason,omitempty"`
+	Status       TemplateRunStatus `json:"status"`
+	TemplateType string            `json:"template_type"`
+	TenantId     string            `json:"tenant_id"`
+}
+
+// TemplateRunStatus defines model for TemplateRunStatus.
+type TemplateRunStatus string
+
 // Tenant defines model for Tenant.
 type Tenant struct {
 	Id       string `json:"id"`
@@ -761,6 +877,16 @@ type TransformValidateResponse struct {
 	Valid   bool             `json:"valid"`
 }
 
+// UpdateChartRequest defines model for UpdateChartRequest.
+type UpdateChartRequest struct {
+	ChartType  ChartType `json:"chart_type"`
+	ConfigJson *string   `json:"config_json,omitempty"`
+	DatasetId  string    `json:"dataset_id"`
+	Dimension  string    `json:"dimension"`
+	Measure    string    `json:"measure"`
+	Name       string    `json:"name"`
+}
+
 // UpdateConnectionRequest defines model for UpdateConnectionRequest.
 type UpdateConnectionRequest struct {
 	ConfigJson   *string `json:"config_json,omitempty"`
@@ -768,6 +894,12 @@ type UpdateConnectionRequest struct {
 	Name         string  `json:"name"`
 	SecretRef    *string `json:"secret_ref,omitempty"`
 	Type         string  `json:"type"`
+}
+
+// UpdateDashboardRequest defines model for UpdateDashboardRequest.
+type UpdateDashboardRequest struct {
+	Description *string `json:"description,omitempty"`
+	Name        string  `json:"name"`
 }
 
 // UpdateDatasetColumnRequest defines model for UpdateDatasetColumnRequest.
@@ -882,6 +1014,39 @@ type GetBillingSubscriptionParams struct {
 // BillingWebhookJSONBody defines parameters for BillingWebhook.
 type BillingWebhookJSONBody map[string]interface{}
 
+// ListChartsParams defines parameters for ListCharts.
+type ListChartsParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// CreateChartParams defines parameters for CreateChart.
+type CreateChartParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// DeleteChartParams defines parameters for DeleteChart.
+type DeleteChartParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// GetChartParams defines parameters for GetChart.
+type GetChartParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// UpdateChartParams defines parameters for UpdateChart.
+type UpdateChartParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// GetChartDataParams defines parameters for GetChartData.
+type GetChartDataParams struct {
+	Period    *ChartPeriod        `form:"period,omitempty" json:"period,omitempty"`
+	StartDate *openapi_types.Date `form:"start_date,omitempty" json:"start_date,omitempty"`
+	EndDate   *openapi_types.Date `form:"end_date,omitempty" json:"end_date,omitempty"`
+	XTenantID XTenantID           `json:"X-Tenant-ID"`
+}
+
 // ListConnectionsParams defines parameters for ListConnections.
 type ListConnectionsParams struct {
 	XTenantID XTenantID `json:"X-Tenant-ID"`
@@ -948,6 +1113,46 @@ type StartGoogleCredentialOAuthParams struct {
 
 // DeleteCredentialParams defines parameters for DeleteCredential.
 type DeleteCredentialParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// ListDashboardsParams defines parameters for ListDashboards.
+type ListDashboardsParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// CreateDashboardParams defines parameters for CreateDashboard.
+type CreateDashboardParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// ListDashboardWidgetsParams defines parameters for ListDashboardWidgets.
+type ListDashboardWidgetsParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// CreateDashboardWidgetParams defines parameters for CreateDashboardWidget.
+type CreateDashboardWidgetParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// DeleteDashboardWidgetParams defines parameters for DeleteDashboardWidget.
+type DeleteDashboardWidgetParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// DeleteDashboardParams defines parameters for DeleteDashboard.
+type DeleteDashboardParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// GetDashboardParams defines parameters for GetDashboard.
+type GetDashboardParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// UpdateDashboardParams defines parameters for UpdateDashboard.
+type UpdateDashboardParams struct {
 	XTenantID XTenantID `json:"X-Tenant-ID"`
 }
 
@@ -1098,6 +1303,21 @@ type GetTenantPlanParams struct {
 	XTenantID XTenantID `json:"X-Tenant-ID"`
 }
 
+// ListTemplateRunsParams defines parameters for ListTemplateRuns.
+type ListTemplateRunsParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// CreateTemplateRunParams defines parameters for CreateTemplateRun.
+type CreateTemplateRunParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
+// GetTemplateRunParams defines parameters for GetTemplateRun.
+type GetTemplateRunParams struct {
+	XTenantID XTenantID `json:"X-Tenant-ID"`
+}
+
 // CreateInvitationParams defines parameters for CreateInvitation.
 type CreateInvitationParams struct {
 	XTenantID XTenantID `json:"X-Tenant-ID"`
@@ -1178,6 +1398,12 @@ type CreateBillingPortalSessionJSONRequestBody = CreateBillingPortalSessionReque
 // BillingWebhookJSONRequestBody defines body for BillingWebhook for application/json ContentType.
 type BillingWebhookJSONRequestBody BillingWebhookJSONBody
 
+// CreateChartJSONRequestBody defines body for CreateChart for application/json ContentType.
+type CreateChartJSONRequestBody = CreateChartRequest
+
+// UpdateChartJSONRequestBody defines body for UpdateChart for application/json ContentType.
+type UpdateChartJSONRequestBody = UpdateChartRequest
+
 // CreateConnectionJSONRequestBody defines body for CreateConnection for application/json ContentType.
 type CreateConnectionJSONRequestBody = CreateConnectionRequest
 
@@ -1186,6 +1412,15 @@ type TestConnectionJSONRequestBody = TestConnectionRequest
 
 // UpdateConnectionJSONRequestBody defines body for UpdateConnection for application/json ContentType.
 type UpdateConnectionJSONRequestBody = UpdateConnectionRequest
+
+// CreateDashboardJSONRequestBody defines body for CreateDashboard for application/json ContentType.
+type CreateDashboardJSONRequestBody = CreateDashboardRequest
+
+// CreateDashboardWidgetJSONRequestBody defines body for CreateDashboardWidget for application/json ContentType.
+type CreateDashboardWidgetJSONRequestBody = CreateDashboardWidgetRequest
+
+// UpdateDashboardJSONRequestBody defines body for UpdateDashboard for application/json ContentType.
+type UpdateDashboardJSONRequestBody = UpdateDashboardRequest
 
 // UpdateDatasetColumnsJSONRequestBody defines body for UpdateDatasetColumns for application/json ContentType.
 type UpdateDatasetColumnsJSONRequestBody = UpdateDatasetColumnsRequest
@@ -1213,6 +1448,9 @@ type CreateModuleTypeJSONRequestBody = CreateModuleTypeRequest
 
 // CreateModuleTypeSchemaJSONRequestBody defines body for CreateModuleTypeSchema for application/json ContentType.
 type CreateModuleTypeSchemaJSONRequestBody = CreateModuleTypeSchemaRequest
+
+// CreateTemplateRunJSONRequestBody defines body for CreateTemplateRun for application/json ContentType.
+type CreateTemplateRunJSONRequestBody = CreateTemplateRunRequest
 
 // CreateInvitationJSONRequestBody defines body for CreateInvitation for application/json ContentType.
 type CreateInvitationJSONRequestBody = CreateInvitationRequest

--- a/apps/node/web/src/lib/api/generated.ts
+++ b/apps/node/web/src/lib/api/generated.ts
@@ -985,6 +985,167 @@ export interface paths {
         patch: operations["updateMemberRole"];
         trace?: never;
     };
+    "/api/v1/dashboards": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List dashboards */
+        get: operations["listDashboards"];
+        put?: never;
+        /** Create dashboard */
+        post: operations["createDashboard"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/dashboards/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get dashboard */
+        get: operations["getDashboard"];
+        /** Update dashboard */
+        put: operations["updateDashboard"];
+        post?: never;
+        /** Delete dashboard */
+        delete: operations["deleteDashboard"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/dashboards/{dashboard_id}/widgets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List dashboard widgets */
+        get: operations["listDashboardWidgets"];
+        put?: never;
+        /** Create dashboard widget */
+        post: operations["createDashboardWidget"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/dashboards/{dashboard_id}/widgets/{widget_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete dashboard widget */
+        delete: operations["deleteDashboardWidget"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/charts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List charts */
+        get: operations["listCharts"];
+        put?: never;
+        /** Create chart */
+        post: operations["createChart"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/charts/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get chart */
+        get: operations["getChart"];
+        /** Update chart */
+        put: operations["updateChart"];
+        post?: never;
+        /** Delete chart */
+        delete: operations["deleteChart"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/charts/{id}/data": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get chart data */
+        get: operations["getChartData"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/template_runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List template runs */
+        get: operations["listTemplateRuns"];
+        put?: never;
+        /** Create template run */
+        post: operations["createTemplateRun"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/template_runs/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get template run */
+        get: operations["getTemplateRun"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1588,6 +1749,95 @@ export interface components {
             job: components["schemas"]["Job"];
             version: components["schemas"]["JobVersion"];
             job_run?: components["schemas"]["JobRun"];
+        };
+        /** @enum {string} */
+        ChartType: "line" | "bar" | "pie";
+        /** @enum {string} */
+        ChartPeriod: "last_7_days" | "last_30_days" | "last_90_days" | "custom";
+        /** @enum {string} */
+        TemplateRunStatus: "success" | "failed" | "skipped";
+        Dashboard: {
+            id: string;
+            tenant_id: string;
+            name: string;
+            description?: string;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        Chart: {
+            id: string;
+            tenant_id: string;
+            name: string;
+            chart_type: components["schemas"]["ChartType"];
+            dataset_id: string;
+            measure: string;
+            dimension: string;
+            config_json?: string;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+        };
+        DashboardWidget: {
+            id: string;
+            dashboard_id: string;
+            chart_id: string;
+            position: number;
+            /** Format: date-time */
+            created_at: string;
+        };
+        TemplateRun: {
+            id: string;
+            tenant_id: string;
+            template_type: string;
+            status: components["schemas"]["TemplateRunStatus"];
+            skip_reason?: string;
+            dashboard_id?: string;
+            /** Format: date-time */
+            created_at: string;
+        };
+        ChartDataResponse: {
+            chart_id: string;
+            period: components["schemas"]["ChartPeriod"];
+            labels: string[];
+            datasets: components["schemas"]["ChartDataset"][];
+        };
+        ChartDataset: {
+            label: string;
+            data: number[];
+        };
+        CreateDashboardRequest: {
+            name: string;
+            description?: string;
+        };
+        UpdateDashboardRequest: {
+            name: string;
+            description?: string;
+        };
+        CreateChartRequest: {
+            name: string;
+            chart_type: components["schemas"]["ChartType"];
+            dataset_id: string;
+            measure: string;
+            dimension: string;
+            config_json?: string;
+        };
+        UpdateChartRequest: {
+            name: string;
+            chart_type: components["schemas"]["ChartType"];
+            dataset_id: string;
+            measure: string;
+            dimension: string;
+            config_json?: string;
+        };
+        CreateDashboardWidgetRequest: {
+            chart_id: string;
+            position: number;
+        };
+        CreateTemplateRunRequest: {
+            template_type: string;
         };
     };
     responses: {
@@ -3465,6 +3715,467 @@ export interface operations {
             400: components["responses"]["ErrorResponse"];
             401: components["responses"]["ErrorResponse"];
             403: components["responses"]["ErrorResponse"];
+        };
+    };
+    listDashboards: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of dashboards */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        items: components["schemas"]["Dashboard"][];
+                    };
+                };
+            };
+            401: components["responses"]["ErrorResponse"];
+        };
+    };
+    createDashboard: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateDashboardRequest"];
+            };
+        };
+        responses: {
+            /** @description Created dashboard */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Dashboard"];
+                };
+            };
+            400: components["responses"]["ErrorResponse"];
+            401: components["responses"]["ErrorResponse"];
+        };
+    };
+    getDashboard: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Dashboard detail */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Dashboard"];
+                };
+            };
+            401: components["responses"]["ErrorResponse"];
+            404: components["responses"]["ErrorResponse"];
+        };
+    };
+    updateDashboard: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateDashboardRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated dashboard */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Dashboard"];
+                };
+            };
+            400: components["responses"]["ErrorResponse"];
+            401: components["responses"]["ErrorResponse"];
+            404: components["responses"]["ErrorResponse"];
+        };
+    };
+    deleteDashboard: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["ErrorResponse"];
+            404: components["responses"]["ErrorResponse"];
+        };
+    };
+    listDashboardWidgets: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path: {
+                dashboard_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of widgets */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        items: components["schemas"]["DashboardWidget"][];
+                    };
+                };
+            };
+            401: components["responses"]["ErrorResponse"];
+            404: components["responses"]["ErrorResponse"];
+        };
+    };
+    createDashboardWidget: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path: {
+                dashboard_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateDashboardWidgetRequest"];
+            };
+        };
+        responses: {
+            /** @description Created widget */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DashboardWidget"];
+                };
+            };
+            400: components["responses"]["ErrorResponse"];
+            401: components["responses"]["ErrorResponse"];
+            404: components["responses"]["ErrorResponse"];
+        };
+    };
+    deleteDashboardWidget: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path: {
+                dashboard_id: string;
+                widget_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["ErrorResponse"];
+            404: components["responses"]["ErrorResponse"];
+        };
+    };
+    listCharts: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of charts */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        items: components["schemas"]["Chart"][];
+                    };
+                };
+            };
+            401: components["responses"]["ErrorResponse"];
+        };
+    };
+    createChart: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateChartRequest"];
+            };
+        };
+        responses: {
+            /** @description Created chart */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Chart"];
+                };
+            };
+            400: components["responses"]["ErrorResponse"];
+            401: components["responses"]["ErrorResponse"];
+        };
+    };
+    getChart: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Chart detail */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Chart"];
+                };
+            };
+            401: components["responses"]["ErrorResponse"];
+            404: components["responses"]["ErrorResponse"];
+        };
+    };
+    updateChart: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateChartRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated chart */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Chart"];
+                };
+            };
+            400: components["responses"]["ErrorResponse"];
+            401: components["responses"]["ErrorResponse"];
+            404: components["responses"]["ErrorResponse"];
+        };
+    };
+    deleteChart: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["ErrorResponse"];
+            404: components["responses"]["ErrorResponse"];
+        };
+    };
+    getChartData: {
+        parameters: {
+            query?: {
+                period?: components["schemas"]["ChartPeriod"];
+                start_date?: string;
+                end_date?: string;
+            };
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Chart data */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ChartDataResponse"];
+                };
+            };
+            401: components["responses"]["ErrorResponse"];
+            404: components["responses"]["ErrorResponse"];
+        };
+    };
+    listTemplateRuns: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of template runs */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        items: components["schemas"]["TemplateRun"][];
+                    };
+                };
+            };
+            401: components["responses"]["ErrorResponse"];
+        };
+    };
+    createTemplateRun: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateTemplateRunRequest"];
+            };
+        };
+        responses: {
+            /** @description Created template run */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TemplateRun"];
+                };
+            };
+            400: components["responses"]["ErrorResponse"];
+            401: components["responses"]["ErrorResponse"];
+        };
+    };
+    getTemplateRun: {
+        parameters: {
+            query?: never;
+            header: {
+                "X-Tenant-ID": components["parameters"]["XTenantID"];
+            };
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Template run detail */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TemplateRun"];
+                };
+            };
+            401: components["responses"]["ErrorResponse"];
+            404: components["responses"]["ErrorResponse"];
         };
     };
 }

--- a/spec/openapi/v1.yaml
+++ b/spec/openapi/v1.yaml
@@ -25,6 +25,9 @@ tags:
   - name: members
   - name: transform
   - name: import
+  - name: dashboards
+  - name: charts
+  - name: template_runs
 paths:
   /healthz:
     get:
@@ -1913,6 +1916,473 @@ paths:
         "409":
           $ref: "#/components/responses/ErrorResponse"
 
+  # ---- Dashboards ----
+  /api/v1/dashboards:
+    post:
+      tags: [dashboards]
+      summary: Create dashboard
+      operationId: createDashboard
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateDashboardRequest"
+      responses:
+        "201":
+          description: Created dashboard
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Dashboard"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+    get:
+      tags: [dashboards]
+      summary: List dashboards
+      operationId: listDashboards
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+      responses:
+        "200":
+          description: List of dashboards
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Dashboard"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+  /api/v1/dashboards/{id}:
+    get:
+      tags: [dashboards]
+      summary: Get dashboard
+      operationId: getDashboard
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Dashboard detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Dashboard"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+    put:
+      tags: [dashboards]
+      summary: Update dashboard
+      operationId: updateDashboard
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateDashboardRequest"
+      responses:
+        "200":
+          description: Updated dashboard
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Dashboard"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+    delete:
+      tags: [dashboards]
+      summary: Delete dashboard
+      operationId: deleteDashboard
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Deleted
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+
+  # ---- Dashboard Widgets ----
+  /api/v1/dashboards/{dashboard_id}/widgets:
+    post:
+      tags: [dashboards]
+      summary: Create dashboard widget
+      operationId: createDashboardWidget
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+        - name: dashboard_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateDashboardWidgetRequest"
+      responses:
+        "201":
+          description: Created widget
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DashboardWidget"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+    get:
+      tags: [dashboards]
+      summary: List dashboard widgets
+      operationId: listDashboardWidgets
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+        - name: dashboard_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: List of widgets
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DashboardWidget"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+  /api/v1/dashboards/{dashboard_id}/widgets/{widget_id}:
+    delete:
+      tags: [dashboards]
+      summary: Delete dashboard widget
+      operationId: deleteDashboardWidget
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+        - name: dashboard_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: widget_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Deleted
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+
+  # ---- Charts ----
+  /api/v1/charts:
+    post:
+      tags: [charts]
+      summary: Create chart
+      operationId: createChart
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateChartRequest"
+      responses:
+        "201":
+          description: Created chart
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Chart"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+    get:
+      tags: [charts]
+      summary: List charts
+      operationId: listCharts
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+      responses:
+        "200":
+          description: List of charts
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Chart"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+  /api/v1/charts/{id}:
+    get:
+      tags: [charts]
+      summary: Get chart
+      operationId: getChart
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Chart detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Chart"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+    put:
+      tags: [charts]
+      summary: Update chart
+      operationId: updateChart
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateChartRequest"
+      responses:
+        "200":
+          description: Updated chart
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Chart"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+    delete:
+      tags: [charts]
+      summary: Delete chart
+      operationId: deleteChart
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Deleted
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+
+  # ---- Chart Data ----
+  /api/v1/charts/{id}/data:
+    get:
+      tags: [charts]
+      summary: Get chart data
+      operationId: getChartData
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: period
+          in: query
+          required: false
+          schema:
+            $ref: "#/components/schemas/ChartPeriod"
+        - name: start_date
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+        - name: end_date
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+      responses:
+        "200":
+          description: Chart data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChartDataResponse"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+
+  # ---- Template Runs ----
+  /api/v1/template_runs:
+    post:
+      tags: [template_runs]
+      summary: Create template run
+      operationId: createTemplateRun
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateTemplateRunRequest"
+      responses:
+        "201":
+          description: Created template run
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TemplateRun"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+    get:
+      tags: [template_runs]
+      summary: List template runs
+      operationId: listTemplateRuns
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+      responses:
+        "200":
+          description: List of template runs
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/TemplateRun"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+  /api/v1/template_runs/{id}:
+    get:
+      tags: [template_runs]
+      summary: Get template run
+      operationId: getTemplateRun
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: "#/components/parameters/XTenantID"
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Template run detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TemplateRun"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "404":
+          $ref: "#/components/responses/ErrorResponse"
+
 components:
   parameters:
     XTenantID:
@@ -3113,3 +3583,182 @@ components:
           $ref: "#/components/schemas/JobVersion"
         job_run:
           $ref: "#/components/schemas/JobRun"
+
+    # ---- Dashboard / Chart / Widget / TemplateRun ----
+    ChartType:
+      type: string
+      enum: [line, bar, pie]
+    ChartPeriod:
+      type: string
+      enum: [last_7_days, last_30_days, last_90_days, custom]
+    TemplateRunStatus:
+      type: string
+      enum: [success, failed, skipped]
+
+    Dashboard:
+      type: object
+      required: [id, tenant_id, name, created_at, updated_at]
+      properties:
+        id:
+          type: string
+        tenant_id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    Chart:
+      type: object
+      required: [id, tenant_id, name, chart_type, dataset_id, measure, dimension, created_at, updated_at]
+      properties:
+        id:
+          type: string
+        tenant_id:
+          type: string
+        name:
+          type: string
+        chart_type:
+          $ref: "#/components/schemas/ChartType"
+        dataset_id:
+          type: string
+        measure:
+          type: string
+        dimension:
+          type: string
+        config_json:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    DashboardWidget:
+      type: object
+      required: [id, dashboard_id, chart_id, position, created_at]
+      properties:
+        id:
+          type: string
+        dashboard_id:
+          type: string
+        chart_id:
+          type: string
+        position:
+          type: integer
+        created_at:
+          type: string
+          format: date-time
+    TemplateRun:
+      type: object
+      required: [id, tenant_id, template_type, status, created_at]
+      properties:
+        id:
+          type: string
+        tenant_id:
+          type: string
+        template_type:
+          type: string
+        status:
+          $ref: "#/components/schemas/TemplateRunStatus"
+        skip_reason:
+          type: string
+        dashboard_id:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+    ChartDataResponse:
+      type: object
+      required: [chart_id, period, labels, datasets]
+      properties:
+        chart_id:
+          type: string
+        period:
+          $ref: "#/components/schemas/ChartPeriod"
+        labels:
+          type: array
+          items:
+            type: string
+        datasets:
+          type: array
+          items:
+            $ref: "#/components/schemas/ChartDataset"
+    ChartDataset:
+      type: object
+      required: [label, data]
+      properties:
+        label:
+          type: string
+        data:
+          type: array
+          items:
+            type: number
+
+    CreateDashboardRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+    UpdateDashboardRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+    CreateChartRequest:
+      type: object
+      required: [name, chart_type, dataset_id, measure, dimension]
+      properties:
+        name:
+          type: string
+        chart_type:
+          $ref: "#/components/schemas/ChartType"
+        dataset_id:
+          type: string
+        measure:
+          type: string
+        dimension:
+          type: string
+        config_json:
+          type: string
+    UpdateChartRequest:
+      type: object
+      required: [name, chart_type, dataset_id, measure, dimension]
+      properties:
+        name:
+          type: string
+        chart_type:
+          $ref: "#/components/schemas/ChartType"
+        dataset_id:
+          type: string
+        measure:
+          type: string
+        dimension:
+          type: string
+        config_json:
+          type: string
+    CreateDashboardWidgetRequest:
+      type: object
+      required: [chart_id, position]
+      properties:
+        chart_id:
+          type: string
+        position:
+          type: integer
+    CreateTemplateRunRequest:
+      type: object
+      required: [template_type]
+      properties:
+        template_type:
+          type: string


### PR DESCRIPTION
## Summary
- Add 17 tenant-scoped API endpoints for dashboards, charts, dashboard widgets, chart data, and template runs to `spec/openapi/v1.yaml`
- Add 14 schemas (3 enums, 6 entities, 5 request types) covering the visualization feature set
- Generate Go (backend + e2e-cli) and TypeScript types via `make openapi-generate`

Closes #128

## Test plan
- [x] `make openapi-lint` passes
- [x] `make openapi-generate` succeeds (Go + TS types generated)
- [ ] Implementation and build validation in #129+

🤖 Generated with [Claude Code](https://claude.com/claude-code)