### PR TITLE
feat(db): add visualization tables migration (#130)

### DIFF
--- a/apps/golang/backend/db/migrations/000019_create_dashboards_charts.down.sql
+++ b/apps/golang/backend/db/migrations/000019_create_dashboards_charts.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS template_runs;
+DROP TABLE IF EXISTS dashboard_widgets;
+DROP TABLE IF EXISTS charts;
+DROP TABLE IF EXISTS dashboards;

--- a/apps/golang/backend/db/migrations/000019_create_dashboards_charts.up.sql
+++ b/apps/golang/backend/db/migrations/000019_create_dashboards_charts.up.sql
@@ -1,0 +1,46 @@
+CREATE TABLE dashboards (
+    id          TEXT PRIMARY KEY,
+    tenant_id   TEXT NOT NULL REFERENCES tenants(id),
+    name        TEXT NOT NULL,
+    description TEXT,
+    created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+    updated_at  DATETIME NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_dashboards_tenant_id ON dashboards(tenant_id);
+
+CREATE TABLE charts (
+    id          TEXT PRIMARY KEY,
+    tenant_id   TEXT NOT NULL REFERENCES tenants(id),
+    name        TEXT NOT NULL,
+    chart_type  TEXT NOT NULL CHECK(chart_type IN ('line', 'bar', 'pie')),
+    dataset_id  TEXT NOT NULL REFERENCES datasets(id),
+    measure     TEXT NOT NULL,
+    dimension   TEXT NOT NULL,
+    config_json TEXT,
+    created_at  DATETIME NOT NULL DEFAULT (datetime('now')),
+    updated_at  DATETIME NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_charts_tenant_id ON charts(tenant_id);
+CREATE INDEX idx_charts_dataset_id ON charts(dataset_id);
+
+CREATE TABLE dashboard_widgets (
+    id           TEXT PRIMARY KEY,
+    dashboard_id TEXT NOT NULL REFERENCES dashboards(id) ON DELETE CASCADE,
+    chart_id     TEXT NOT NULL REFERENCES charts(id) ON DELETE CASCADE,
+    position     INTEGER NOT NULL DEFAULT 0,
+    created_at   DATETIME NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(dashboard_id, chart_id)
+);
+CREATE INDEX idx_dashboard_widgets_dashboard_id ON dashboard_widgets(dashboard_id);
+CREATE INDEX idx_dashboard_widgets_chart_id ON dashboard_widgets(chart_id);
+
+CREATE TABLE template_runs (
+    id             TEXT PRIMARY KEY,
+    tenant_id      TEXT NOT NULL REFERENCES tenants(id),
+    template_type  TEXT NOT NULL,
+    status         TEXT NOT NULL CHECK(status IN ('success', 'failed', 'skipped')),
+    skip_reason    TEXT,
+    dashboard_id   TEXT REFERENCES dashboards(id),
+    created_at     DATETIME NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_template_runs_tenant_id ON template_runs(tenant_id);


### PR DESCRIPTION
## Summary
- Add migration `000019_create_dashboards_charts` with 4 new tables: `dashboards`, `charts`, `dashboard_widgets`, `template_runs`
- Prerequisite for Backend CRUD implementation (#131)
- Verified: `make up` → migration applied to version 19, `make health` all green

## Test plan
- [x] `make up` — migration auto-applied (`database migrated to version 19`)
- [x] `make health` — API, Web, Valkey all healthy
- [x] No errors or panics in container logs

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)