### PR TITLE
docs: add automatic project board status updates to skills

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -93,3 +93,33 @@ EOF
 ```
 
 作成された PR の URL を報告する。
+
+### 6. Project Board Status 更新
+
+PR に `Closes #N` が含まれている場合、対象 issue の Status を **Review** に更新する:
+
+```bash
+# 1. item_id を取得
+gh project item-list 2 --owner 3106k --format json | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for item in data.get('items', []):
+    if item.get('content', {}).get('number') == <issue_number>:
+        print(item['id'])
+"
+
+# 2. Status → Review に更新
+gh api graphql -f query='
+mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "PVT_kwHOAC1ux84BQwnR"
+    itemId: "<item_id>"
+    fieldId: "PVTSSF_lAHOAC1ux84BQwnRzg-yVxk"
+    value: { singleSelectOptionId: "f99654d4" }
+  }) {
+    projectV2Item { id }
+  }
+}'
+```
+
+更新結果を報告する。

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -82,3 +82,33 @@ EOF
 ```
 
 投稿した旨を報告する。
+
+### 6. Project Board Status 更新
+
+実装プランが承認され着手する場合、issue の Status を **In Progress** に更新する:
+
+```bash
+# 1. item_id を取得
+gh project item-list 2 --owner 3106k --format json | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for item in data.get('items', []):
+    if item.get('content', {}).get('number') == <issue_number>:
+        print(item['id'])
+"
+
+# 2. Status → In Progress に更新
+gh api graphql -f query='
+mutation {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: "PVT_kwHOAC1ux84BQwnR"
+    itemId: "<item_id>"
+    fieldId: "PVTSSF_lAHOAC1ux84BQwnRzg-yVxk"
+    value: { singleSelectOptionId: "47fc9ee4" }
+  }) {
+    projectV2Item { id }
+  }
+}'
+```
+
+更新前に WIP 制限 (In Progress 最大 2 件) を確認し、超える場合はユーザーに警告する。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -605,4 +605,12 @@ Playwright で `browser_take_screenshot` を使用した場合、確認完了後
 - **完了条件**: 実装 + 生成/テスト + PR merge + Issue close で Done
 - **緊急割り込み**: P0 で In Progress に割り込み可。理由を issue コメントに 1 行残す
 
+### Status 更新の実行タイミング
+
+issue に着手・PR 作成・マージ時は、**必ず `/project` スキルで Status を更新すること**:
+
+- **issue 着手時**: `/project update <issue#> status "In progress"` を実行
+- **PR 作成時**: `/create-pr` が自動で Status → Review に更新する
+- **マージ後**: Status → Done に更新し、ブロックしていた issue の Blocked を解除
+
 詳細な操作方法・field ID は `/project` スキルを参照。


### PR DESCRIPTION
## Summary
- CLAUDE.md に Status 更新の実行タイミングを明記（着手時・PR作成時・マージ後）
- `/create-pr` に Step 6 追加: PR 作成後に対象 issue の Status → Review を自動更新
- `/plan-issue` に Step 6 追加: プラン承認・着手時に Status → In Progress を更新 + WIP 制限チェック

## Test plan
- [ ] `/create-pr` で PR 作成後に issue Status が Review に更新されること
- [ ] `/plan-issue` で着手時に issue Status が In Progress に更新されること
- [ ] WIP 制限 (2件) 超過時に警告が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)