### PR TITLE
refactor(openapi): replace Google Sheets fields with generic source_config

### DIFF
--- a/apps/golang/backend/internal/openapi/types.gen.go
+++ b/apps/golang/backend/internal/openapi/types.gen.go
@@ -343,14 +343,15 @@ type CreateEdgeInput struct {
 
 // CreateImportJobRequest defines model for CreateImportJobRequest.
 type CreateImportJobRequest struct {
-	ConnectionId  string           `json:"connection_id"`
-	Description   *string          `json:"description,omitempty"`
-	Execution     *ImportExecution `json:"execution,omitempty"`
-	Name          string           `json:"name"`
-	Range         *string          `json:"range,omitempty"`
-	SheetName     *string          `json:"sheet_name,omitempty"`
-	Slug          string           `json:"slug"`
-	SpreadsheetId string           `json:"spreadsheet_id"`
+	// ConnectionId ID of the source connection (connector type is derived from connection)
+	ConnectionId string           `json:"connection_id"`
+	Description  *string          `json:"description,omitempty"`
+	Execution    *ImportExecution `json:"execution,omitempty"`
+	Name         string           `json:"name"`
+	Slug         string           `json:"slug"`
+
+	// SourceConfig Connector-specific source configuration (e.g. {spreadsheet_id, sheet_name, range} for Google Sheets)
+	SourceConfig *map[string]interface{} `json:"source_config,omitempty"`
 }
 
 // CreateImportJobResponse defines model for CreateImportJobResponse.

--- a/apps/golang/e2e-cli/internal/openapi/types.gen.go
+++ b/apps/golang/e2e-cli/internal/openapi/types.gen.go
@@ -343,14 +343,15 @@ type CreateEdgeInput struct {
 
 // CreateImportJobRequest defines model for CreateImportJobRequest.
 type CreateImportJobRequest struct {
-	ConnectionId  string           `json:"connection_id"`
-	Description   *string          `json:"description,omitempty"`
-	Execution     *ImportExecution `json:"execution,omitempty"`
-	Name          string           `json:"name"`
-	Range         *string          `json:"range,omitempty"`
-	SheetName     *string          `json:"sheet_name,omitempty"`
-	Slug          string           `json:"slug"`
-	SpreadsheetId string           `json:"spreadsheet_id"`
+	// ConnectionId ID of the source connection (connector type is derived from connection)
+	ConnectionId string           `json:"connection_id"`
+	Description  *string          `json:"description,omitempty"`
+	Execution    *ImportExecution `json:"execution,omitempty"`
+	Name         string           `json:"name"`
+	Slug         string           `json:"slug"`
+
+	// SourceConfig Connector-specific source configuration (e.g. {spreadsheet_id, sheet_name, range} for Google Sheets)
+	SourceConfig *map[string]interface{} `json:"source_config,omitempty"`
 }
 
 // CreateImportJobResponse defines model for CreateImportJobResponse.

--- a/apps/node/web/src/lib/api/generated.ts
+++ b/apps/node/web/src/lib/api/generated.ts
@@ -1739,10 +1739,12 @@ export interface components {
             name: string;
             slug: string;
             description?: string;
+            /** @description ID of the source connection (connector type is derived from connection) */
             connection_id: string;
-            spreadsheet_id: string;
-            sheet_name?: string;
-            range?: string;
+            /** @description Connector-specific source configuration (e.g. {spreadsheet_id, sheet_name, range} for Google Sheets) */
+            source_config?: {
+                [key: string]: unknown;
+            };
             execution?: components["schemas"]["ImportExecution"];
         };
         CreateImportJobResponse: {

--- a/spec/openapi/v1.yaml
+++ b/spec/openapi/v1.yaml
@@ -3555,7 +3555,7 @@ components:
       enum: [save_only, immediate]
     CreateImportJobRequest:
       type: object
-      required: [name, slug, connection_id, spreadsheet_id]
+      required: [name, slug, connection_id]
       properties:
         name:
           type: string
@@ -3565,12 +3565,11 @@ components:
           type: string
         connection_id:
           type: string
-        spreadsheet_id:
-          type: string
-        sheet_name:
-          type: string
-        range:
-          type: string
+          description: ID of the source connection (connector type is derived from connection)
+        source_config:
+          type: object
+          additionalProperties: true
+          description: Connector-specific source configuration (e.g. {spreadsheet_id, sheet_name, range} for Google Sheets)
         execution:
           $ref: "#/components/schemas/ImportExecution"
     CreateImportJobResponse:


### PR DESCRIPTION
## Summary
- Remove `spreadsheet_id`, `sheet_name`, `range` from `CreateImportJobRequest` schema
- Add `source_config` (object, additionalProperties) to support connector-agnostic import job creation
- Regenerate Go (backend + e2e-cli) and TypeScript types

Closes #145

## Test plan
- [x] `make openapi-lint` passes
- [x] `make openapi-generate` produces expected types
- [ ] `make openapi-check` passes after commit (no drift)
- [ ] Go backend build will fail until R2 (handler/usecase migration) — expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)