### PR TITLE
test(import): add E2E compatibility tests and migration note

### DIFF
--- a/apps/golang/e2e-cli/internal/config/config.go
+++ b/apps/golang/e2e-cli/internal/config/config.go
@@ -27,7 +27,7 @@ func Load(args []string) (*Config, error) {
 	baseURL := fs.String("base-url", envOr("E2E_BASE_URL", "http://localhost:8080"), "API base URL")
 	token := fs.String("token", envOr("E2E_TOKEN", ""), "Bearer token for authenticated requests")
 	tenantID := fs.String("tenant-id", envOr("E2E_TENANT_ID", ""), "Tenant header value")
-	suitesRaw := fs.String("suites", envOr("E2E_SUITES", "health,auth,metrics,connectors,connections,datasets,events,jobs,job_runs,module_types,uploads,plan,billing,tenant,members,admin"), "Comma separated suite names")
+	suitesRaw := fs.String("suites", envOr("E2E_SUITES", "health,auth,metrics,connectors,connections,datasets,events,import,jobs,job_runs,module_types,uploads,plan,billing,tenant,members,admin"), "Comma separated suite names")
 	jsonOut := fs.String("json-out", envOr("E2E_JSON_OUT", "e2e-report.json"), "JSON report output path")
 	authEmail := fs.String("auth-email", envOr("E2E_AUTH_EMAIL", ""), "Email for auth suite (optional)")
 	authPassword := fs.String("auth-password", envOr("E2E_AUTH_PASSWORD", "Passw0rd!123"), "Password for auth suite")

--- a/apps/golang/e2e-cli/internal/suite/import/happy_path/scenario.go
+++ b/apps/golang/e2e-cli/internal/suite/import/happy_path/scenario.go
@@ -1,0 +1,168 @@
+package happy_path
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/user/micro-dp/e2e-cli/internal/httpclient"
+	"github.com/user/micro-dp/e2e-cli/internal/openapi"
+)
+
+type Scenario struct {
+	password    string
+	displayName string
+}
+
+func NewScenario(password, displayName string) *Scenario {
+	return &Scenario{
+		password:    password,
+		displayName: displayName,
+	}
+}
+
+func (s *Scenario) ID() string {
+	return "import/happy_path/create_import_job"
+}
+
+func (s *Scenario) Run(ctx context.Context, client *httpclient.Client) error {
+	ts := time.Now().UnixNano()
+
+	// 1. Register new user
+	email := fmt.Sprintf("e2e_import_%d@example.com", ts)
+	registerReq := openapi.RegisterRequest{
+		Email:       openapi.Email(email),
+		Password:    s.password,
+		DisplayName: openapi.Ptr(s.displayName),
+	}
+	var registerResp openapi.RegisterResponse
+	code, body, err := client.PostJSON(ctx, "/api/v1/auth/register", registerReq, &registerResp)
+	if err != nil {
+		return err
+	}
+	if code != 201 {
+		return fmt.Errorf("register: status=%d body=%s", code, string(body))
+	}
+
+	// 2. Login
+	loginReq := openapi.LoginRequest{
+		Email:    openapi.Email(email),
+		Password: s.password,
+	}
+	var loginResp openapi.LoginResponse
+	code, body, err = client.PostJSON(ctx, "/api/v1/auth/login", loginReq, &loginResp)
+	if err != nil {
+		return err
+	}
+	if code != 200 {
+		return fmt.Errorf("login: status=%d body=%s", code, string(body))
+	}
+	client.SetToken(loginResp.Token)
+	client.SetTenantID(registerResp.TenantId)
+
+	// 3. Create a source-google-sheets connection
+	connConfig := `{"credentials_json":"{}"}`
+	createConnReq := openapi.CreateConnectionRequest{
+		Name:       "e2e-gsheets",
+		Type:       "source-google-sheets",
+		ConfigJson: openapi.Ptr(connConfig),
+	}
+	var connResp openapi.Connection
+	code, body, err = client.PostJSON(ctx, "/api/v1/connections", createConnReq, &connResp)
+	if err != nil {
+		return err
+	}
+	if code != 201 {
+		return fmt.Errorf("create connection: status=%d body=%s", code, string(body))
+	}
+	connID := connResp.Id
+
+	// 4. Normal: POST /api/v1/import/jobs with source_config → 201
+	srcCfg := map[string]interface{}{
+		"spreadsheet_id": "abc123",
+		"sheet_name":     "Sheet1",
+		"range":          "A1:Z1000",
+	}
+	exec := openapi.ImportExecutionSaveOnly
+	createReq := openapi.CreateImportJobRequest{
+		Name:         "e2e-import",
+		Slug:         fmt.Sprintf("e2e-import-%d", ts),
+		ConnectionId: connID,
+		Description:  openapi.Ptr("E2E import test"),
+		Execution:    &exec,
+		SourceConfig: &srcCfg,
+	}
+	var createResp openapi.CreateImportJobResponse
+	code, body, err = client.PostJSON(ctx, "/api/v1/import/jobs", createReq, &createResp)
+	if err != nil {
+		return err
+	}
+	if code != 201 {
+		return fmt.Errorf("create import job: status=%d body=%s", code, string(body))
+	}
+	if createResp.Job.Id == "" {
+		return fmt.Errorf("create import job: job.id is empty")
+	}
+	if createResp.Version.Id == "" {
+		return fmt.Errorf("create import job: version.id is empty")
+	}
+
+	// 5. source_config omitted → 201 (optional field)
+	createReqNoSrc := openapi.CreateImportJobRequest{
+		Name:         "e2e-import-no-src",
+		Slug:         fmt.Sprintf("e2e-import-no-src-%d", ts),
+		ConnectionId: connID,
+		Execution:    &exec,
+	}
+	var createRespNoSrc openapi.CreateImportJobResponse
+	code, body, err = client.PostJSON(ctx, "/api/v1/import/jobs", createReqNoSrc, &createRespNoSrc)
+	if err != nil {
+		return err
+	}
+	if code != 201 {
+		return fmt.Errorf("create import job (no source_config): status=%d body=%s", code, string(body))
+	}
+
+	// 6. Validation: name missing → 400
+	createReqNoName := openapi.CreateImportJobRequest{
+		Name:         "",
+		Slug:         fmt.Sprintf("e2e-import-noname-%d", ts),
+		ConnectionId: connID,
+	}
+	code, body, err = client.PostJSON(ctx, "/api/v1/import/jobs", createReqNoName, nil)
+	if err != nil {
+		return err
+	}
+	if code != 400 {
+		return fmt.Errorf("create import job (no name): expected 400 got=%d body=%s", code, string(body))
+	}
+
+	// 7. Validation: connection_id missing → 400
+	createReqNoConn := openapi.CreateImportJobRequest{
+		Name: "e2e-import-noconn",
+		Slug: fmt.Sprintf("e2e-import-noconn-%d", ts),
+	}
+	code, body, err = client.PostJSON(ctx, "/api/v1/import/jobs", createReqNoConn, nil)
+	if err != nil {
+		return err
+	}
+	if code != 400 {
+		return fmt.Errorf("create import job (no connection_id): expected 400 got=%d body=%s", code, string(body))
+	}
+
+	// 8. Invalid connection_id → 400
+	createReqBadConn := openapi.CreateImportJobRequest{
+		Name:         "e2e-import-badconn",
+		Slug:         fmt.Sprintf("e2e-import-badconn-%d", ts),
+		ConnectionId: "nonexistent-connection-id",
+	}
+	code, body, err = client.PostJSON(ctx, "/api/v1/import/jobs", createReqBadConn, nil)
+	if err != nil {
+		return err
+	}
+	if code != 400 {
+		return fmt.Errorf("create import job (bad connection_id): expected 400 got=%d body=%s", code, string(body))
+	}
+
+	return nil
+}

--- a/apps/golang/e2e-cli/internal/suite/suite.go
+++ b/apps/golang/e2e-cli/internal/suite/suite.go
@@ -28,6 +28,7 @@ import (
 	plancase "github.com/user/micro-dp/e2e-cli/internal/suite/plan/happy_path"
 	adminmultitenant "github.com/user/micro-dp/e2e-cli/internal/suite/tenant/admin_multi_tenant"
 	tenantisolation "github.com/user/micro-dp/e2e-cli/internal/suite/tenant/isolation"
+	importcase "github.com/user/micro-dp/e2e-cli/internal/suite/import/happy_path"
 	uploadscase "github.com/user/micro-dp/e2e-cli/internal/suite/uploads/happy_path"
 )
 
@@ -66,6 +67,8 @@ func Build(cfg *config.Config) ([]runner.Scenario, error) {
 			scenarios = append(scenarios, jobrunscase.NewScenario("", cfg.AuthPassword, cfg.DisplayName))
 		case "module_types":
 			scenarios = append(scenarios, moduletypescase.NewScenario(cfg.AuthPassword, cfg.DisplayName))
+		case "import":
+			scenarios = append(scenarios, importcase.NewScenario(cfg.AuthPassword, cfg.DisplayName))
 		case "uploads":
 			scenarios = append(scenarios, uploadscase.NewScenario(cfg.AuthPassword, cfg.DisplayName))
 		case "plan":

--- a/docs/migration/import-api-source-config.md
+++ b/docs/migration/import-api-source-config.md
@@ -1,0 +1,53 @@
+# Import API: source_config Migration
+
+## Summary
+
+The Import Job creation API (`POST /api/v1/import/jobs`) has been migrated from
+connector-specific top-level fields to a generic `source_config` object.
+
+## What Changed
+
+**Before (removed):**
+
+```json
+{
+  "name": "my-import",
+  "slug": "my-import",
+  "connection_id": "conn-123",
+  "spreadsheet_id": "abc123",
+  "sheet_name": "Sheet1",
+  "range": "A1:Z1000"
+}
+```
+
+**After (current):**
+
+```json
+{
+  "name": "my-import",
+  "slug": "my-import",
+  "connection_id": "conn-123",
+  "source_config": {
+    "spreadsheet_id": "abc123",
+    "sheet_name": "Sheet1",
+    "range": "A1:Z1000"
+  }
+}
+```
+
+## Key Points
+
+- `source_config` is an optional JSON object. Connector-specific parameters that
+  were previously top-level fields are now nested under this key.
+- The old fields (`spreadsheet_id`, `sheet_name`, `range`) have been removed from
+  the request schema. There is no backwards-compatibility shim.
+- `connection_id` determines the connector type. `source_config` carries
+  connector-specific configuration that varies by connector.
+- If `source_config` is omitted, an empty config is used (valid for connectors
+  that require no additional parameters).
+
+## Migration Steps
+
+1. Update request payloads to move connector-specific fields into `source_config`.
+2. Update any client code or SDK integrations that construct `CreateImportJobRequest`.
+3. No database migration is required — the change is API-layer only.


### PR DESCRIPTION
## Summary
- Add `import` E2E suite testing `POST /api/v1/import/jobs` with `source_config` (happy path, optional omission, validation errors)
- Register import suite in e2e-cli config defaults
- Add migration note documenting old top-level fields → `source_config` transition

Closes #163

## Test plan
- [x] `cd apps/golang/e2e-cli && go build ./...`
- [x] `make down && make up && make health`
- [x] `make e2e-cli` — import suite passes (21 passed, 0 failed, 4 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)