### PR TITLE
refactor: add capabilities model to connector definitions

### DIFF
--- a/apps/golang/backend/handler/convert.go
+++ b/apps/golang/backend/handler/convert.go
@@ -290,10 +290,15 @@ func toOpenAPIUsageSummary(s *domain.UsageSummary) openapi.UsageSummaryResponse 
 }
 
 func toOpenAPIConnectorDefinition(d *connector.Definition) openapi.ConnectorDefinition {
+	caps := d.Capabilities
+	if caps == nil {
+		caps = []string{}
+	}
 	out := openapi.ConnectorDefinition{
-		Id:   d.ID,
-		Name: d.Name,
-		Kind: openapi.ConnectorKind(d.Kind),
+		Id:           d.ID,
+		Name:         d.Name,
+		Kind:         openapi.ConnectorKind(d.Kind),
+		Capabilities: caps,
 	}
 	if d.Icon != "" {
 		out.Icon = &d.Icon
@@ -305,10 +310,15 @@ func toOpenAPIConnectorDefinition(d *connector.Definition) openapi.ConnectorDefi
 }
 
 func toOpenAPIConnectorDefinitionDetail(d *connector.Definition) openapi.ConnectorDefinitionDetail {
+	caps := d.Capabilities
+	if caps == nil {
+		caps = []string{}
+	}
 	out := openapi.ConnectorDefinitionDetail{
-		Id:   d.ID,
-		Name: d.Name,
-		Kind: openapi.ConnectorKind(d.Kind),
+		Id:           d.ID,
+		Name:         d.Name,
+		Kind:         openapi.ConnectorKind(d.Kind),
+		Capabilities: caps,
 	}
 	if d.Icon != "" {
 		out.Icon = &d.Icon

--- a/apps/golang/backend/internal/connector/definitions/destinations/postgres.json
+++ b/apps/golang/backend/internal/connector/definitions/destinations/postgres.json
@@ -4,6 +4,7 @@
   "kind": "destination",
   "icon": "postgres",
   "description": "Write data to PostgreSQL databases",
+  "capabilities": [],
   "spec": {
     "type": "object",
     "required": ["host", "port", "database", "username", "password"],

--- a/apps/golang/backend/internal/connector/definitions/destinations/s3.json
+++ b/apps/golang/backend/internal/connector/definitions/destinations/s3.json
@@ -4,6 +4,7 @@
   "kind": "destination",
   "icon": "s3",
   "description": "Write data to Amazon S3 buckets",
+  "capabilities": [],
   "spec": {
     "type": "object",
     "required": ["bucket", "region", "auth_method"],

--- a/apps/golang/backend/internal/connector/definitions/sources/google-sheets.json
+++ b/apps/golang/backend/internal/connector/definitions/sources/google-sheets.json
@@ -5,6 +5,7 @@
   "icon": "google-sheets",
   "description": "Read data from Google Spreadsheets",
   "x-credential-provider": "google",
+  "capabilities": ["testable", "fetchable", "importable"],
   "spec": {
     "type": "object",
     "properties": {}

--- a/apps/golang/backend/internal/connector/definitions/sources/mysql.json
+++ b/apps/golang/backend/internal/connector/definitions/sources/mysql.json
@@ -4,6 +4,7 @@
   "kind": "source",
   "icon": "mysql",
   "description": "Read data from MySQL databases",
+  "capabilities": ["testable"],
   "spec": {
     "type": "object",
     "required": ["host", "port", "database", "username", "password"],

--- a/apps/golang/backend/internal/connector/definitions/sources/postgres.json
+++ b/apps/golang/backend/internal/connector/definitions/sources/postgres.json
@@ -4,6 +4,7 @@
   "kind": "source",
   "icon": "postgres",
   "description": "Read data from PostgreSQL databases",
+  "capabilities": ["testable"],
   "spec": {
     "type": "object",
     "required": ["host", "port", "database", "username", "password"],

--- a/apps/golang/backend/internal/connector/definitions/sources/s3.json
+++ b/apps/golang/backend/internal/connector/definitions/sources/s3.json
@@ -4,6 +4,7 @@
   "kind": "source",
   "icon": "s3",
   "description": "Read data from Amazon S3 buckets",
+  "capabilities": [],
   "spec": {
     "type": "object",
     "required": ["bucket", "region", "auth_method"],

--- a/apps/golang/backend/internal/connector/registry.go
+++ b/apps/golang/backend/internal/connector/registry.go
@@ -22,7 +22,18 @@ type Definition struct {
 	Icon               string          `json:"icon"`
 	Description        string          `json:"description"`
 	CredentialProvider string          `json:"x-credential-provider"`
+	Capabilities       []string        `json:"capabilities"`
 	Spec               json.RawMessage `json:"spec"`
+}
+
+// HasCapability returns true if the definition includes the given capability.
+func (d *Definition) HasCapability(cap string) bool {
+	for _, c := range d.Capabilities {
+		if c == cap {
+			return true
+		}
+	}
+	return false
 }
 
 // Registry holds all connector definitions and their compiled JSON Schemas.

--- a/apps/golang/backend/internal/openapi/types.gen.go
+++ b/apps/golang/backend/internal/openapi/types.gen.go
@@ -282,15 +282,19 @@ type ConnectionSchemasResponse struct {
 
 // ConnectorDefinition defines model for ConnectorDefinition.
 type ConnectorDefinition struct {
-	Description *string       `json:"description,omitempty"`
-	Icon        *string       `json:"icon,omitempty"`
-	Id          string        `json:"id"`
-	Kind        ConnectorKind `json:"kind"`
-	Name        string        `json:"name"`
+	// Capabilities Supported capabilities (testable, fetchable, importable)
+	Capabilities []string      `json:"capabilities"`
+	Description  *string       `json:"description,omitempty"`
+	Icon         *string       `json:"icon,omitempty"`
+	Id           string        `json:"id"`
+	Kind         ConnectorKind `json:"kind"`
+	Name         string        `json:"name"`
 }
 
 // ConnectorDefinitionDetail defines model for ConnectorDefinitionDetail.
 type ConnectorDefinitionDetail struct {
+	// Capabilities Supported capabilities (testable, fetchable, importable)
+	Capabilities       []string               `json:"capabilities"`
 	CredentialProvider *string                `json:"credential_provider,omitempty"`
 	Description        *string                `json:"description,omitempty"`
 	Icon               *string                `json:"icon,omitempty"`

--- a/apps/golang/e2e-cli/internal/openapi/types.gen.go
+++ b/apps/golang/e2e-cli/internal/openapi/types.gen.go
@@ -282,15 +282,19 @@ type ConnectionSchemasResponse struct {
 
 // ConnectorDefinition defines model for ConnectorDefinition.
 type ConnectorDefinition struct {
-	Description *string       `json:"description,omitempty"`
-	Icon        *string       `json:"icon,omitempty"`
-	Id          string        `json:"id"`
-	Kind        ConnectorKind `json:"kind"`
-	Name        string        `json:"name"`
+	// Capabilities Supported capabilities (testable, fetchable, importable)
+	Capabilities []string      `json:"capabilities"`
+	Description  *string       `json:"description,omitempty"`
+	Icon         *string       `json:"icon,omitempty"`
+	Id           string        `json:"id"`
+	Kind         ConnectorKind `json:"kind"`
+	Name         string        `json:"name"`
 }
 
 // ConnectorDefinitionDetail defines model for ConnectorDefinitionDetail.
 type ConnectorDefinitionDetail struct {
+	// Capabilities Supported capabilities (testable, fetchable, importable)
+	Capabilities       []string               `json:"capabilities"`
 	CredentialProvider *string                `json:"credential_provider,omitempty"`
 	Description        *string                `json:"description,omitempty"`
 	Icon               *string                `json:"icon,omitempty"`

--- a/apps/node/web/src/lib/api/generated.ts
+++ b/apps/node/web/src/lib/api/generated.ts
@@ -1506,6 +1506,8 @@ export interface components {
             kind: components["schemas"]["ConnectorKind"];
             icon?: string;
             description?: string;
+            /** @description Supported capabilities (testable, fetchable, importable) */
+            capabilities: string[];
         };
         ConnectorDefinitionDetail: {
             id: string;
@@ -1514,6 +1516,8 @@ export interface components {
             icon?: string;
             description?: string;
             credential_provider?: string;
+            /** @description Supported capabilities (testable, fetchable, importable) */
+            capabilities: string[];
             spec: Record<string, never>;
         };
         Credential: {

--- a/spec/openapi/v1.yaml
+++ b/spec/openapi/v1.yaml
@@ -3104,7 +3104,7 @@ components:
       enum: [source, destination]
     ConnectorDefinition:
       type: object
-      required: [id, name, kind]
+      required: [id, name, kind, capabilities]
       properties:
         id:
           type: string
@@ -3116,9 +3116,14 @@ components:
           type: string
         description:
           type: string
+        capabilities:
+          type: array
+          items:
+            type: string
+          description: Supported capabilities (testable, fetchable, importable)
     ConnectorDefinitionDetail:
       type: object
-      required: [id, name, kind, spec]
+      required: [id, name, kind, spec, capabilities]
       properties:
         id:
           type: string
@@ -3132,6 +3137,11 @@ components:
           type: string
         credential_provider:
           type: string
+        capabilities:
+          type: array
+          items:
+            type: string
+          description: Supported capabilities (testable, fetchable, importable)
         spec:
           type: object
 


### PR DESCRIPTION
## Summary
- Add `capabilities` array (`testable`, `fetchable`, `importable`) to all 6 connector definition JSON files as SSOT
- Update `Definition` struct with `Capabilities` field and `HasCapability` method in registry
- Expose capabilities in OpenAPI spec (`ConnectorDefinition` + `ConnectorDefinitionDetail`) and regenerate Go/TS types

## Test plan
- [x] `make openapi-check` (lint + generate)
- [x] `go build ./...` (backend + e2e-cli)
- [x] `make up && make health` (all services healthy)
- [x] `make e2e-cli` — 18 passed, 2 failed (pre-existing OAuth), 4 skipped
- [ ] `GET /api/v1/connectors` returns capabilities per connector

🤖 Generated with [Claude Code](https://claude.com/claude-code)