### PR TITLE
refactor: split TestConnectionResponse into validation/connectivity

### DIFF
--- a/apps/golang/backend/handler/connection.go
+++ b/apps/golang/backend/handler/connection.go
@@ -180,8 +180,23 @@ func (h *ConnectionHandler) Test(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate config against JSON Schema
+	validationResult := openapi.ValidationResult{Status: openapi.ValidationResultStatusOk}
 	if err := h.registry.ValidateConfig(req.Type, req.ConfigJson); err != nil {
-		writeError(w, http.StatusUnprocessableEntity, err.Error())
+		msg := err.Error()
+		validationResult = openapi.ValidationResult{
+			Status:  openapi.ValidationResultStatusFailed,
+			Message: &msg,
+		}
+		// Return early: no point testing connectivity with invalid config
+		skipMsg := "skipped due to validation failure"
+		writeJSON(w, http.StatusOK, openapi.TestConnectionResponse{
+			Validation: validationResult,
+			Connectivity: openapi.ConnectivityResult{
+				Status:  openapi.ConnectivityResultStatusSkipped,
+				Message: &skipMsg,
+			},
+		})
 		return
 	}
 
@@ -200,9 +215,12 @@ func (h *ConnectionHandler) Test(w http.ResponseWriter, r *http.Request) {
 				code := "unauthorized"
 				msg := "failed to retrieve access token"
 				writeJSON(w, http.StatusOK, openapi.TestConnectionResponse{
-					Status:  openapi.TestConnectionResponseStatusFailed,
-					Code:    &code,
-					Message: &msg,
+					Validation: validationResult,
+					Connectivity: openapi.ConnectivityResult{
+						Status:  openapi.ConnectivityResultStatusFailed,
+						Code:    &code,
+						Message: &msg,
+					},
 				})
 				return
 			}
@@ -210,21 +228,29 @@ func (h *ConnectionHandler) Test(w http.ResponseWriter, r *http.Request) {
 		}
 
 		result := tester.Test(r.Context(), req.ConfigJson, accessToken)
-		status := openapi.TestConnectionResponseStatusOk
+		connStatus := openapi.ConnectivityResultStatusOk
 		if !result.OK {
-			status = openapi.TestConnectionResponseStatusFailed
+			connStatus = openapi.ConnectivityResultStatusFailed
 		}
 		writeJSON(w, http.StatusOK, openapi.TestConnectionResponse{
-			Status:  status,
-			Code:    &result.Code,
-			Message: &result.Message,
+			Validation: validationResult,
+			Connectivity: openapi.ConnectivityResult{
+				Status:  connStatus,
+				Code:    &result.Code,
+				Message: &result.Message,
+			},
 		})
 		return
 	}
 
-	// Fallback: schema validation only
+	// No tester registered: report connectivity as skipped
+	skipMsg := "no connectivity test available for this connector type"
 	writeJSON(w, http.StatusOK, openapi.TestConnectionResponse{
-		Status: openapi.TestConnectionResponseStatusOk,
+		Validation: validationResult,
+		Connectivity: openapi.ConnectivityResult{
+			Status:  openapi.ConnectivityResultStatusSkipped,
+			Message: &skipMsg,
+		},
 	})
 }
 

--- a/apps/golang/backend/internal/openapi/types.gen.go
+++ b/apps/golang/backend/internal/openapi/types.gen.go
@@ -28,6 +28,13 @@ const (
 	Pie  ChartType = "pie"
 )
 
+// Defines values for ConnectivityResultStatus.
+const (
+	ConnectivityResultStatusFailed  ConnectivityResultStatus = "failed"
+	ConnectivityResultStatusOk      ConnectivityResultStatus = "ok"
+	ConnectivityResultStatusSkipped ConnectivityResultStatus = "skipped"
+)
+
 // Defines values for ConnectorKind.
 const (
 	ConnectorKindDestination ConnectorKind = "destination"
@@ -128,9 +135,9 @@ const (
 
 // Defines values for TemplateRunStatus.
 const (
-	Failed  TemplateRunStatus = "failed"
-	Skipped TemplateRunStatus = "skipped"
-	Success TemplateRunStatus = "success"
+	TemplateRunStatusFailed  TemplateRunStatus = "failed"
+	TemplateRunStatusSkipped TemplateRunStatus = "skipped"
+	TemplateRunStatusSuccess TemplateRunStatus = "success"
 )
 
 // Defines values for TenantInvitationStatus.
@@ -147,12 +154,6 @@ const (
 	Owner  TenantRole = "owner"
 )
 
-// Defines values for TestConnectionResponseStatus.
-const (
-	TestConnectionResponseStatusFailed TestConnectionResponseStatus = "failed"
-	TestConnectionResponseStatusOk     TestConnectionResponseStatus = "ok"
-)
-
 // Defines values for TransformExecution.
 const (
 	TransformExecutionImmediate TransformExecution = "immediate"
@@ -164,6 +165,12 @@ const (
 const (
 	Presigned UploadStatus = "presigned"
 	Uploaded  UploadStatus = "uploaded"
+)
+
+// Defines values for ValidationResultStatus.
+const (
+	ValidationResultStatusFailed ValidationResultStatus = "failed"
+	ValidationResultStatusOk     ValidationResultStatus = "ok"
 )
 
 // AdminCreateTenantRequest defines model for AdminCreateTenantRequest.
@@ -279,6 +286,16 @@ type ConnectionSchemasResponse struct {
 	Items []SchemaItem `json:"items"`
 	Title string       `json:"title"`
 }
+
+// ConnectivityResult defines model for ConnectivityResult.
+type ConnectivityResult struct {
+	Code    *string                  `json:"code,omitempty"`
+	Message *string                  `json:"message,omitempty"`
+	Status  ConnectivityResultStatus `json:"status"`
+}
+
+// ConnectivityResultStatus defines model for ConnectivityResult.Status.
+type ConnectivityResultStatus string
 
 // ConnectorDefinition defines model for ConnectorDefinition.
 type ConnectorDefinition struct {
@@ -877,13 +894,9 @@ type TestConnectionRequest struct {
 
 // TestConnectionResponse defines model for TestConnectionResponse.
 type TestConnectionResponse struct {
-	Code    *string                      `json:"code,omitempty"`
-	Message *string                      `json:"message,omitempty"`
-	Status  TestConnectionResponseStatus `json:"status"`
+	Connectivity ConnectivityResult `json:"connectivity"`
+	Validation   ValidationResult   `json:"validation"`
 }
-
-// TestConnectionResponseStatus defines model for TestConnectionResponse.Status.
-type TestConnectionResponseStatus string
 
 // TransformExecution defines model for TransformExecution.
 type TransformExecution string
@@ -1024,6 +1037,15 @@ type UsageSummaryResponse struct {
 	StorageBytes int64  `json:"storage_bytes"`
 	UploadsCount int    `json:"uploads_count"`
 }
+
+// ValidationResult defines model for ValidationResult.
+type ValidationResult struct {
+	Message *string                `json:"message,omitempty"`
+	Status  ValidationResultStatus `json:"status"`
+}
+
+// ValidationResultStatus defines model for ValidationResult.Status.
+type ValidationResultStatus string
 
 // WriteKey defines model for WriteKey.
 type WriteKey struct {

--- a/apps/golang/e2e-cli/internal/openapi/types.gen.go
+++ b/apps/golang/e2e-cli/internal/openapi/types.gen.go
@@ -28,6 +28,13 @@ const (
 	Pie  ChartType = "pie"
 )
 
+// Defines values for ConnectivityResultStatus.
+const (
+	ConnectivityResultStatusFailed  ConnectivityResultStatus = "failed"
+	ConnectivityResultStatusOk      ConnectivityResultStatus = "ok"
+	ConnectivityResultStatusSkipped ConnectivityResultStatus = "skipped"
+)
+
 // Defines values for ConnectorKind.
 const (
 	ConnectorKindDestination ConnectorKind = "destination"
@@ -128,9 +135,9 @@ const (
 
 // Defines values for TemplateRunStatus.
 const (
-	Failed  TemplateRunStatus = "failed"
-	Skipped TemplateRunStatus = "skipped"
-	Success TemplateRunStatus = "success"
+	TemplateRunStatusFailed  TemplateRunStatus = "failed"
+	TemplateRunStatusSkipped TemplateRunStatus = "skipped"
+	TemplateRunStatusSuccess TemplateRunStatus = "success"
 )
 
 // Defines values for TenantInvitationStatus.
@@ -147,12 +154,6 @@ const (
 	Owner  TenantRole = "owner"
 )
 
-// Defines values for TestConnectionResponseStatus.
-const (
-	TestConnectionResponseStatusFailed TestConnectionResponseStatus = "failed"
-	TestConnectionResponseStatusOk     TestConnectionResponseStatus = "ok"
-)
-
 // Defines values for TransformExecution.
 const (
 	TransformExecutionImmediate TransformExecution = "immediate"
@@ -164,6 +165,12 @@ const (
 const (
 	Presigned UploadStatus = "presigned"
 	Uploaded  UploadStatus = "uploaded"
+)
+
+// Defines values for ValidationResultStatus.
+const (
+	ValidationResultStatusFailed ValidationResultStatus = "failed"
+	ValidationResultStatusOk     ValidationResultStatus = "ok"
 )
 
 // AdminCreateTenantRequest defines model for AdminCreateTenantRequest.
@@ -279,6 +286,16 @@ type ConnectionSchemasResponse struct {
 	Items []SchemaItem `json:"items"`
 	Title string       `json:"title"`
 }
+
+// ConnectivityResult defines model for ConnectivityResult.
+type ConnectivityResult struct {
+	Code    *string                  `json:"code,omitempty"`
+	Message *string                  `json:"message,omitempty"`
+	Status  ConnectivityResultStatus `json:"status"`
+}
+
+// ConnectivityResultStatus defines model for ConnectivityResult.Status.
+type ConnectivityResultStatus string
 
 // ConnectorDefinition defines model for ConnectorDefinition.
 type ConnectorDefinition struct {
@@ -877,13 +894,9 @@ type TestConnectionRequest struct {
 
 // TestConnectionResponse defines model for TestConnectionResponse.
 type TestConnectionResponse struct {
-	Code    *string                      `json:"code,omitempty"`
-	Message *string                      `json:"message,omitempty"`
-	Status  TestConnectionResponseStatus `json:"status"`
+	Connectivity ConnectivityResult `json:"connectivity"`
+	Validation   ValidationResult   `json:"validation"`
 }
-
-// TestConnectionResponseStatus defines model for TestConnectionResponse.Status.
-type TestConnectionResponseStatus string
 
 // TransformExecution defines model for TransformExecution.
 type TransformExecution string
@@ -1024,6 +1037,15 @@ type UsageSummaryResponse struct {
 	StorageBytes int64  `json:"storage_bytes"`
 	UploadsCount int    `json:"uploads_count"`
 }
+
+// ValidationResult defines model for ValidationResult.
+type ValidationResult struct {
+	Message *string                `json:"message,omitempty"`
+	Status  ValidationResultStatus `json:"status"`
+}
+
+// ValidationResultStatus defines model for ValidationResult.Status.
+type ValidationResultStatus string
 
 // WriteKey defines model for WriteKey.
 type WriteKey struct {

--- a/apps/golang/e2e-cli/internal/suite/connectors/happy_path/scenario.go
+++ b/apps/golang/e2e-cli/internal/suite/connectors/happy_path/scenario.go
@@ -165,21 +165,29 @@ func (s *Scenario) Run(ctx context.Context, client *httpclient.Client) error {
 	if code != 200 {
 		return fmt.Errorf("test connection (valid): status=%d body=%s", code, string(body))
 	}
-	if testResp.Status != openapi.TestConnectionResponseStatusOk {
-		return fmt.Errorf("test connection: expected status=ok got=%s", testResp.Status)
+	if testResp.Validation.Status != openapi.ValidationResultStatusOk {
+		return fmt.Errorf("test connection: expected validation.status=ok got=%s", testResp.Validation.Status)
+	}
+	// source-postgres has no tester registered → connectivity should be skipped
+	if testResp.Connectivity.Status != openapi.ConnectivityResultStatusSkipped {
+		return fmt.Errorf("test connection: expected connectivity.status=skipped got=%s", testResp.Connectivity.Status)
 	}
 
-	// 11. POST /api/v1/connections/test (invalid config) → 422
+	// 11. POST /api/v1/connections/test (invalid config) → 200 with validation.status=failed
 	testInvalidReq := openapi.TestConnectionRequest{
 		Type:       "source-postgres",
 		ConfigJson: "{}",
 	}
-	code, body, err = client.PostJSON(ctx, "/api/v1/connections/test", testInvalidReq, nil)
+	var testInvalidResp openapi.TestConnectionResponse
+	code, body, err = client.PostJSON(ctx, "/api/v1/connections/test", testInvalidReq, &testInvalidResp)
 	if err != nil {
 		return err
 	}
-	if code != 422 {
-		return fmt.Errorf("test connection (invalid): expected 422 got=%d body=%s", code, string(body))
+	if code != 200 {
+		return fmt.Errorf("test connection (invalid): expected 200 got=%d body=%s", code, string(body))
+	}
+	if testInvalidResp.Validation.Status != openapi.ValidationResultStatusFailed {
+		return fmt.Errorf("test connection (invalid): expected validation.status=failed got=%s", testInvalidResp.Validation.Status)
 	}
 
 	return nil

--- a/apps/node/web/src/app/(app)/connections/connections-manager.tsx
+++ b/apps/node/web/src/app/(app)/connections/connections-manager.tsx
@@ -165,12 +165,24 @@ export function ConnectionsManager({
         pushToast({ variant: "error", message: data.error ?? "Test failed" });
         return;
       }
-      if (data.status === "ok") {
+      const { validation, connectivity } = data;
+      if (validation.status === "failed") {
+        pushToast({
+          variant: "error",
+          message: `Validation failed: ${validation.message ?? "invalid configuration"}`,
+        });
+      } else if (connectivity.status === "ok") {
         pushToast({ variant: "success", message: "Connection test passed" });
+      } else if (connectivity.status === "skipped") {
+        pushToast({
+          variant: "info",
+          message:
+            "Configuration is valid. Connectivity test is not available for this connector type.",
+        });
       } else {
         pushToast({
           variant: "error",
-          message: `Test failed: ${data.message ?? "unknown error"}`,
+          message: `Connectivity failed: ${connectivity.message ?? "unknown error"}`,
         });
       }
     } catch (e) {

--- a/apps/node/web/src/lib/api/generated.ts
+++ b/apps/node/web/src/lib/api/generated.ts
@@ -1493,8 +1493,17 @@ export interface components {
             credential_id?: string;
         };
         TestConnectionResponse: {
+            validation: components["schemas"]["ValidationResult"];
+            connectivity: components["schemas"]["ConnectivityResult"];
+        };
+        ValidationResult: {
             /** @enum {string} */
             status: "ok" | "failed";
+            message?: string;
+        };
+        ConnectivityResult: {
+            /** @enum {string} */
+            status: "ok" | "failed" | "skipped";
             message?: string;
             code?: string;
         };

--- a/spec/openapi/v1.yaml
+++ b/spec/openapi/v1.yaml
@@ -3098,11 +3098,28 @@ components:
           type: string
     TestConnectionResponse:
       type: object
+      required: [validation, connectivity]
+      properties:
+        validation:
+          $ref: "#/components/schemas/ValidationResult"
+        connectivity:
+          $ref: "#/components/schemas/ConnectivityResult"
+    ValidationResult:
+      type: object
       required: [status]
       properties:
         status:
           type: string
           enum: [ok, failed]
+        message:
+          type: string
+    ConnectivityResult:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum: [ok, failed, skipped]
         message:
           type: string
         code:


### PR DESCRIPTION
## Summary
- Split `TestConnectionResponse` into `validation` (schema check) and `connectivity` (actual test) sub-objects
- Add `skipped` status for connectors without a registered tester, replacing misleading `ok`
- Update frontend to show distinct toast messages for validation failure, connectivity success/failure, and skipped states

Closes #149

## Test plan
- [x] `make openapi-check` — spec and generated types in sync
- [x] `go build ./...` — backend and e2e-cli compile
- [x] `make up && make health` — all services healthy
- [x] `make e2e-cli` — `connectors/happy_path/crud_and_test` passes
- [x] Manual curl: valid config + no tester → `connectivity.status: skipped`
- [x] Manual curl: invalid config → `validation.status: failed`
- [ ] UI review: test connection button shows correct toasts for each state

🤖 Generated with [Claude Code](https://claude.com/claude-code)