### PR TITLE
[Research] micro-dp 機能ギャップ分析レポート

### DIFF
--- a/docs/research/2026-03-21-feature-gap-analysis.md
+++ b/docs/research/2026-03-21-feature-gap-analysis.md
@@ -1,0 +1,277 @@
+---
+theme: "micro-dp 機能ギャップ分析"
+date: 2026-03-21
+expires_at: 2026-06-21
+confidence: high
+area: "CDP"
+---
+
+# micro-dp 機能ギャップ分析 市場調査レポート
+
+## 調査概要
+
+- 調査日: 2026-03-21
+- テーマ: micro-dp と主要競合の機能カテゴリ比較、不足領域の特定、各競合の差別化ポイント
+- 対象領域: CDP / データパイプライン、プロダクトアナリティクス、BI / ダッシュボード
+- 対象競合: Segment, Fivetran, Airbyte, PostHog, Mixpanel, Metabase, Redash
+
+## micro-dp 現在の機能マップ
+
+CLAUDE.md および codebase から導出した micro-dp の現在の機能:
+
+| カテゴリ | 機能 | 成熟度 |
+|---------|------|--------|
+| イベント収集 | Tracker SDK (Web)、バッチ collect API、Write Key 認証 | ✅ 実装済み |
+| イベントパイプライン | Valkey キュー → Worker → DuckDB → Parquet → MinIO | ✅ 実装済み |
+| CSV インポート | Presigned upload → Worker → Parquet 変換 → Dataset catalog | ✅ 実装済み |
+| 集計パイプライン | Worker ticker ベース (events / visits 集計) | ✅ 実装済み |
+| コネクタフレームワーク | 静的 JSON 定義、source/destination 分離、JSON Schema バリデーション | ✅ 基盤実装済み |
+| ダッシュボード / チャート | CRUD + DuckDB ベース chart data API (line/bar/pie) | ✅ 基本実装済み |
+| マルチテナント | JWT 認証、テナント分離、メンバー招待・ロール管理 | ✅ 実装済み |
+| プラン / クォータ | Plan CRUD、usage metering、quota check (402) | ✅ 実装済み |
+| OAuth 連携 | Credential OAuth provider (Google 実装済み) | ✅ 基盤実装済み |
+| Observability | OpenTelemetry traces + Prometheus metrics | ✅ 実装済み |
+| Feature Flags | OpenFeature ベース基盤 (envProvider) | ✅ 基盤のみ |
+
+---
+
+## 機能カテゴリ比較マトリクス
+
+### 凡例
+
+- ✅ = 成熟した実装あり
+- 🔶 = 部分的 / 基本レベル
+- ❌ = 未実装
+
+| 機能カテゴリ | micro-dp | Segment | Fivetran | Airbyte | PostHog | Mixpanel | Metabase | Redash |
+|-------------|----------|---------|----------|---------|---------|----------|----------|--------|
+| **データ収集** | | | | | | | | |
+| イベント収集 SDK | 🔶 Web のみ | ✅ 全プラットフォーム | ❌ | ❌ | ✅ 全プラットフォーム + autocapture | ✅ 全プラットフォーム | ❌ | ❌ |
+| サーバーサイド SDK | ❌ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
+| CDC (Change Data Capture) | ❌ | ❌ | ✅ log-based | ✅ Debezium | ❌ | ❌ | ❌ | ❌ |
+| コネクタ数 | 🔶 6 定義 | ✅ 550+ | ✅ 700+ | ✅ 600+ | 🔶 25+ | 🔶 Warehouse連携 | ✅ 25+ DB | ✅ 35+ DB |
+| Autocapture (コードレス計測) | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| **データ変換・パイプライン** | | | | | | | | |
+| ELT パイプライン | 🔶 CSV→Parquet のみ | ✅ Reverse ETL | ✅ 700+ source ELT | ✅ 600+ source ELT | 🔶 Data pipelines | ❌ | ❌ | ❌ |
+| dbt 統合 | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| スケジューリング | 🔶 Worker ticker | ✅ 柔軟 | ✅ 分単位スケジュール | ✅ cron + 手動 | ✅ | ❌ | ❌ | ✅ クエリスケジュール |
+| Reverse ETL | ❌ | ✅ Profiles Sync | ✅ Activations | 🔶 | ❌ | ❌ | ❌ | ❌ |
+| **アナリティクス** | | | | | | | | |
+| ファネル分析 | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | 🔶 SQL ベース | 🔶 SQL ベース |
+| リテンション分析 | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
+| コホート分析 | ❌ | 🔶 Audience | ❌ | ❌ | ✅ | ✅ | ❌ | 🔶 Cohort viz |
+| ユーザーセグメンテーション | ❌ | ✅ Audience builder | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
+| ユーザーフロー / パス分析 | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ Flows | ❌ | ❌ |
+| セッションリプレイ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
+| **BI / 可視化** | | | | | | | | |
+| ダッシュボード | 🔶 基本 CRUD | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ |
+| チャート種類 | 🔶 3種 (line/bar/pie) | ❌ | ❌ | ❌ | ✅ 多数 | ✅ 多数 | ✅ 15種以上 | ✅ 12種以上 |
+| SQL クエリビルダー | ❌ | ❌ | ❌ | ❌ | ✅ HogQL | 🔶 | ✅ ビジュアル + SQL | ✅ SQL エディタ |
+| 埋め込みアナリティクス | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ SDK + iframe | 🔶 iframe |
+| アラート / 通知 | ❌ | ❌ | ✅ 同期異常 | ✅ 同期異常 | ✅ | ✅ Anomaly detection | ✅ スケジュール | ✅ スケジュール |
+| **CDP / ユーザー管理** | | | | | | | | |
+| Identity Resolution | ❌ | ✅ Unify | ❌ | ❌ | 🔶 | 🔶 | ❌ | ❌ |
+| ユーザープロファイル統合 | ❌ | ✅ 360° view | ❌ | ❌ | ✅ Person profiles | ✅ User profiles | ❌ | ❌ |
+| Audience / Journey | ❌ | ✅ Engage | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| **プロダクト改善** | | | | | | | | |
+| Feature Flags | 🔶 基盤のみ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
+| A/B テスト | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ |
+| サーベイ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| エラートラッキング | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| **インフラ / 運用** | | | | | | | | |
+| セルフホスト | ✅ Docker Compose | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ✅ |
+| マルチテナント | ✅ | ✅ Workspace | ✅ | 🔶 | ✅ Organization | ✅ Organization | 🔶 | ❌ |
+| API ファースト | ✅ OpenAPI | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+---
+
+## 競合分析
+
+### Segment (Twilio)
+
+- **該当機能**: CDP (Customer Data Platform) — イベント収集 + ユーザー統合 + オーディエンス配信
+- **アプローチ**: 550+ 統合の Data Pipeline (Connections) + Identity Resolution (Unify) + 旅程オーケストレーション (Engage)
+- **料金**: Free (1K visitors/月), Team $120/月〜, Business カスタム (MTU ベース)
+- **強み**: 圧倒的な統合数、リアルタイム Identity Resolution、全プラットフォーム SDK
+- **弱み**: 高コスト (スケール時に数万ドル/月)、クローズドソース、CDP 以外の機能 (BI等) は外部依存
+- **情報源**: [Segment Pricing](https://segment.com/pricing/), [Segment Unify](https://segment.com/product/unify/), [G2 Reviews](https://www.g2.com/products/twilio-segment/reviews)
+
+### Fivetran
+
+- **該当機能**: ELT データパイプライン — ソースからウェアハウスへの自動同期
+- **アプローチ**: 700+ フルマネージドコネクタ、log-based CDC、dbt 統合、Reverse ETL (Activations)
+- **料金**: Free (500K MAR), Standard $5最低/コネクタ〜, Enterprise カスタム。中規模 $1K-$5K/月
+- **強み**: 信頼性の高い CDC、自動スキーマ変更追従、手放し運用
+- **弱み**: 高コスト (2026年にコネクタ別課金へ移行)、クローズドソース、カスタムコネクタ作成が限定的
+- **情報源**: [Fivetran Pricing](https://www.fivetran.com/pricing), [Fivetran Connectors](https://www.fivetran.com/connectors), [Fivetran 2026 Pricing Updates](https://fivetran.com/docs/usage-based-pricing/pricing-updates/2026-pricing-updates)
+
+### Airbyte
+
+- **該当機能**: OSS ELT プラットフォーム — データ統合
+- **アプローチ**: 600+ コネクタ (OSS)、Connector Builder (ノーコード/ローコード)、Debezium CDC、self-host 可能
+- **料金**: OSS 無料, Cloud $10/月〜 ($2.50/credit), Plus $25K/年〜
+- **強み**: OSS (MIT)、カスタムコネクタ容易、Iceberg 対応、セルフホスト可
+- **弱み**: CDC は at-least-once (重複排除要)、運用コスト (セルフホスト時)、UI/UX がエンタープライズ向けではない
+- **情報源**: [Airbyte Pricing](https://airbyte.com/pricing), [Airbyte GitHub](https://github.com/airbytehq/airbyte), [G2 Reviews](https://www.g2.com/products/airbyte/reviews)
+
+### PostHog
+
+- **該当機能**: オールインワンプロダクトアナリティクスプラットフォーム
+- **アプローチ**: Product analytics + Session Replay + Feature Flags + A/B Testing + Surveys + Error Tracking + Data Warehouse + CDP を単一プラットフォームに統合。Autocapture でコードレス計測
+- **料金**: Free (1M events + 5K replays/月), 有料はイベント量ベース。チーム規模で $150-$900/月。無制限シート
+- **強み**: オールインワン (最も機能カバレッジが広い)、Autocapture、OSS、開発者フレンドリー、HogQL (SQL 直接クエリ)
+- **弱み**: BI 機能は専用ツールに劣る、大規模データパイプライン (ELT) は本業でない、エンタープライズ向け機能が成熟途上
+- **情報源**: [PostHog Pricing](https://posthog.com/pricing), [PostHog GitHub](https://github.com/PostHog/posthog), [PostHog G2](https://www.g2.com/products/posthog/reviews)
+
+### Mixpanel
+
+- **該当機能**: プロダクトアナリティクス — イベントベースのユーザー行動分析
+- **アプローチ**: ファネル / リテンション / コホート / フロー分析、セッションリプレイ、A/B テスト、Warehouse Connectors
+- **料金**: Free (1M events/月), Growth $0.00028/event〜, Enterprise $20K/年〜
+- **強み**: アナリティクス分析の深さ (ファネル、リテンション、フロー)、セルフサーブ分析 UI、Warehouse 直接接続
+- **弱み**: データパイプライン機能なし、自社ホスト不可、高トラフィック時のコスト増大
+- **情報源**: [Mixpanel Pricing](https://mixpanel.com/pricing/), [Mixpanel Docs](https://docs.mixpanel.com/docs/features/advanced), [G2 Reviews](https://www.g2.com/products/mixpanel/reviews)
+
+### Metabase
+
+- **該当機能**: OSS BI / ダッシュボード / 埋め込みアナリティクス
+- **アプローチ**: ビジュアル SQL クエリビルダー + 15+ 可視化タイプ + 埋め込み SDK (React) + 25+ DB 接続
+- **料金**: OSS 無料 (セルフホスト), Cloud 有料 (小〜中規模 $5-10/月程度)
+- **強み**: 非エンジニアでも使える UI、埋め込みアナリティクス SDK、豊富な可視化、OSS
+- **弱み**: リアルタイム分析に弱い、イベント収集機能なし、大規模データではパフォーマンス課題
+- **情報源**: [Metabase Pricing](https://www.metabase.com/pricing/), [Metabase Embedded Analytics](https://www.metabase.com/product/embedded-analytics), [Metabase GitHub](https://github.com/metabase/metabase)
+
+### Redash
+
+- **該当機能**: OSS SQL ダッシュボード / データ可視化
+- **アプローチ**: SQL エディタ + 12+ 可視化タイプ + 35+ データソース + クエリスケジュール + API
+- **料金**: OSS 無料 (セルフホスト), Cloud $5-10/月
+- **強み**: SQL ファーストなシンプルさ、多数のデータソース接続、OSS
+- **弱み**: 開発が停滞気味 (2024年以降コミットが減少)、ビジュアルクエリビルダーなし、データ収集機能なし
+- **情報源**: [Redash Product](https://redash.io/product/), [Redash GitHub](https://github.com/getredash/redash), [G2 Reviews](https://www.g2.com/products/redash/reviews)
+
+---
+
+## micro-dp に不足している機能領域
+
+### 優先度 High — 競争力に直結する不足領域
+
+#### 1. プロダクトアナリティクス機能
+
+**不足内容**: ファネル分析、リテンション分析、コホート分析、ユーザーフロー/パス分析
+**競合状況**: PostHog と Mixpanel が完備。これらは SaaS プロダクトの改善サイクルに不可欠
+**micro-dp の現状**: イベント集計 (events/visits) + 基本チャートのみ。収集したイベントデータからの行動分析ができない
+**ギャップの大きさ**: 大 — データは既に収集済み (events Parquet) だが、分析レイヤーが欠如。DuckDB を活用すれば Parquet 上で直接計算可能
+
+#### 2. SQL クエリ / アドホック分析
+
+**不足内容**: ユーザーが自由に SQL を書いてデータを探索する機能
+**競合状況**: Metabase (ビジュアル + SQL)、Redash (SQL)、PostHog (HogQL) が提供
+**micro-dp の現状**: チャートは事前定義のみ (chart API が DuckDB クエリを生成)。ユーザーのアドホック分析不可
+**ギャップの大きさ**: 大 — BI ツールとして訴求するなら必須。DuckDB + Parquet 基盤があるため技術的には拡張可能
+
+#### 3. チャート / 可視化の種類拡充
+
+**不足内容**: 現在 3 種 (line/bar/pie) のみ。テーブル、エリア、散布図、ファネル、コホートマップ、ゲージ等が不足
+**競合状況**: Metabase 15+ 種、Redash 12+ 種、PostHog / Mixpanel も多数
+**micro-dp の現状**: recharts ベースの chart-preview.tsx で 3 種のみ
+**ギャップの大きさ**: 中〜大 — recharts は追加チャート種をサポート可能。フロントエンド拡張で対応可
+
+### 優先度 Medium — 差別化・成長に必要な領域
+
+#### 4. コネクタ実行エンジン (データインポート)
+
+**不足内容**: コネクタ定義は存在するが、実際のデータ取得 (Import) を実行するエンジンが未実装
+**競合状況**: Fivetran (700+)、Airbyte (600+) が本業。Segment (550+) も Connections で提供
+**micro-dp の現状**: `connector/definitions/` に JSON 定義 6 件 (postgres, mysql, s3 source/dest)。`importable` capability は定義可能だが ImportExecutor 未実装
+**ギャップの大きさ**: 大 — ただし全コネクタを自前実装するのは非現実的。優先コネクタ (PostgreSQL, S3) の Import 実装、または Airbyte OSS との連携が現実的
+
+#### 5. サーバーサイド SDK
+
+**不足内容**: バックエンドからのイベント送信 SDK (Python, Node.js, Go 等)
+**競合状況**: Segment, PostHog, Mixpanel が全プラットフォーム SDK を提供
+**micro-dp の現状**: Web tracker SDK (ブラウザ) + collect API (HTTP) のみ。サーバーサイドは curl 等で直接 API を叩く必要がある
+**ギャップの大きさ**: 中 — collect API が存在するため、薄いラッパー SDK で対応可能
+
+#### 6. Identity Resolution / ユーザープロファイル統合
+
+**不足内容**: 匿名ユーザーとログインユーザーの紐づけ、複数デバイス・セッションの統合
+**競合状況**: Segment (Unify) が最も成熟。PostHog, Mixpanel も Person/User profiles を提供
+**micro-dp の現状**: テナント単位のイベント管理のみ。個別ユーザーの行動追跡・統合なし
+**ギャップの大きさ**: 大 — CDP として訴求するなら中核機能だが、実装コストも大きい
+
+#### 7. アラート / 異常検知
+
+**不足内容**: メトリクス閾値アラート、異常検知、スケジュール通知
+**競合状況**: Mixpanel (anomaly detection)、Metabase/Redash (スケジュールアラート)、Fivetran/Airbyte (同期異常)
+**micro-dp の現状**: notification 基盤 (SendGrid/log) は存在するが、データドリブンアラートなし
+**ギャップの大きさ**: 中 — notification 基盤があるため、aggregation 結果に閾値チェックを追加することで段階的に実装可能
+
+### 優先度 Low — 将来的に検討すべき領域
+
+#### 8. セッションリプレイ
+
+**不足内容**: ユーザーの画面操作をビデオのように再生する機能
+**競合状況**: PostHog, Mixpanel が提供。専門ツール (FullStory, Hotjar) も多数
+**micro-dp の現状**: 未実装。tracker SDK は page_view 等のイベントのみ収集
+**ギャップの大きさ**: 大 (実装コスト) — DOM スナップショット収集 + ストレージ + 再生 UI が必要。自前実装より rrweb 等の OSS 活用が現実的
+
+#### 9. A/B テスト / Experimentation
+
+**不足内容**: Feature Flag ベースの実験プラットフォーム (統計的有意差検定含む)
+**競合状況**: PostHog, Mixpanel が統合提供。専門ツール (LaunchDarkly, Statsig) も多数
+**micro-dp の現状**: Feature Flag 基盤 (OpenFeature) はあるが、テナント向けの実験機能ではない
+**ギャップの大きさ**: 中 — FF 基盤の上に実験レイヤーを構築可能だが、統計エンジンが必要
+
+#### 10. 埋め込みアナリティクス
+
+**不足内容**: 顧客のプロダクトにダッシュボード/チャートを埋め込む機能
+**競合状況**: Metabase が React SDK + iframe で強力にサポート
+**micro-dp の現状**: 未実装
+**ギャップの大きさ**: 中 — B2B SaaS 向けの差別化になるが、現時点では自社利用が優先
+
+#### 11. dbt / Transformation 統合
+
+**不足内容**: データ変換レイヤーとの統合 (dbt Core / Cloud)
+**競合状況**: Fivetran, Airbyte が dbt 統合をネイティブ提供
+**micro-dp の現状**: DuckDB in-memory での集計のみ。外部変換ツールとの連携なし
+**ギャップの大きさ**: 低〜中 — DuckDB が dbt-duckdb アダプターを持つため、将来的に統合可能
+
+---
+
+## 各競合の差別化ポイント
+
+| 競合 | 差別化ポイント | micro-dp への示唆 |
+|------|--------------|-----------------|
+| **Segment** | Identity Resolution + 550+ 統合の「データのハブ」ポジション | ユーザー統合は長期目標。統合数で勝負しない戦略が必要 |
+| **Fivetran** | フルマネージド CDC + 「ゼロメンテナンス」の信頼性 | CDC は高コスト領域。優先 source の Import 実装に集中すべき |
+| **Airbyte** | OSS + Connector Builder でカスタムコネクタが容易 | コネクタ作成の仕組み (Connector Builder 的な UI) は参考になる |
+| **PostHog** | オールインワン + Autocapture + 開発者フレンドリー | **最も直接的な競合モデル**。同じ OSS オールインワン路線を目指すなら参考に |
+| **Mixpanel** | アナリティクス分析の深さ (ファネル/リテンション/フロー) | 分析機能を DuckDB + Parquet 上で実装することで差別化可能 |
+| **Metabase** | 非エンジニア向け UI + 埋め込みアナリティクス SDK | ビジュアルクエリビルダーと埋め込み機能は長期的に検討 |
+| **Redash** | SQL ファーストのシンプルさ (ただし開発停滞) | Redash の衰退は機会。SQL エディタ + ダッシュボードで代替可能 |
+
+---
+
+## サマリ
+
+### 市場機会の大きさ: 大
+
+- **最大のギャップ**: プロダクトアナリティクス (ファネル/リテンション/コホート) — データは収集済みだが分析レイヤーが欠如
+- **技術的優位性**: DuckDB + Parquet + MinIO の基盤は高性能な分析に適している。多くの競合が Snowflake / BigQuery 等の外部 DWH に依存する中、組み込み DWH は差別化になる
+- **OSS オールインワン**: PostHog が示したように、「データ収集 + アナリティクス + BI」をワンストップで提供する OSS は市場ニーズがある
+
+### 競合状況: 領域により異なる
+
+- **ELT / データパイプライン**: Fivetran / Airbyte の激戦区。コネクタ数で勝負するのは非現実的
+- **プロダクトアナリティクス**: PostHog / Mixpanel が強いが、OSS セルフホスト + 軽量は差別化余地あり
+- **BI / ダッシュボード**: Metabase が強い OSS 領域。Redash の開発停滞は機会
+
+### micro-dp にとっての示唆
+
+1. **短期 (0-3ヶ月)**: プロダクトアナリティクス基本機能 (ファネル/リテンション) + SQL クエリ + チャート種拡充 → 「収集したデータの価値」を最大化
+2. **中期 (3-6ヶ月)**: コネクタ Import 実装 (PostgreSQL / S3) + サーバーサイド SDK + アラート → データ収集チャネルの拡大
+3. **長期 (6-12ヶ月)**: Identity Resolution + セッションリプレイ + A/B テスト → CDP / プロダクトアナリティクスとしての完成度向上
+4. **戦略的に見送り**: Fivetran/Airbyte 級のコネクタ数競争 (非現実的)、Segment 級の Audience/Journey (市場ポジションが異なる)
+
+**最も参考にすべき競合: PostHog** — 同じ OSS オールインワン路線で、micro-dp の DuckDB + Parquet 基盤は PostHog の ClickHouse 基盤に相当する。PostHog が「プロダクトアナリティクス → CDP → DWH」と拡張した道筋は、micro-dp が「データパイプライン → アナリティクス → BI」と拡張する道筋の参考になる。


### PR DESCRIPTION
## Summary

- micro-dp と主要競合 7 社 (Segment, Fivetran, Airbyte, PostHog, Mixpanel, Metabase, Redash) の機能カテゴリ比較を実施
- データ収集・変換、アナリティクス、BI/可視化、CDP、プロダクト改善の各カテゴリで機能マトリクスを整理
- micro-dp に不足している 11 の機能領域を優先度付きで特定

### 主要な発見

**High priority ギャップ:**
1. **プロダクトアナリティクス** — ファネル/リテンション/コホート分析が未実装。データは収集済みだが分析レイヤーが欠如
2. **SQL クエリ / アドホック分析** — ユーザーが自由にデータ探索できない
3. **チャート種の不足** — 3 種 (line/bar/pie) のみ vs 競合 12-15 種

**戦略的示唆:**
- 最も参考にすべき競合は **PostHog** (同じ OSS オールインワン路線)
- DuckDB + Parquet 基盤を活かした「データパイプライン → アナリティクス → BI」拡張が有効
- コネクタ数での競争 (Fivetran/Airbyte) は非現実的。分析レイヤー強化を優先すべき

## Test plan

- [x] レポートファイル (`docs/research/2026-03-21-feature-gap-analysis.md`) の frontmatter フォーマット確認
- [ ] Strategist によるレポートレビュー・評価

🤖 Generated with [Claude Code](https://claude.com/claude-code)