### PR TITLE
feat: add AggregationQueue domain interface and Valkey implementation

### DIFF
--- a/apps/golang/backend/domain/aggregation_job.go
+++ b/apps/golang/backend/domain/aggregation_job.go
@@ -1,0 +1,15 @@
+package domain
+
+import "context"
+
+type AggregationMessage struct {
+	TenantID string `json:"tenant_id"`
+	Date     string `json:"date"`
+}
+
+type AggregationQueue interface {
+	Enqueue(ctx context.Context, msg AggregationMessage) error
+	Dequeue(ctx context.Context) (*AggregationMessage, error)
+	MarkProcessed(ctx context.Context, tenantID, date string) error
+	EnqueueDLQ(ctx context.Context, msg AggregationMessage, reason string) error
+}

--- a/apps/golang/backend/queue/aggregation_queue.go
+++ b/apps/golang/backend/queue/aggregation_queue.go
@@ -1,0 +1,84 @@
+package queue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/user/micro-dp/domain"
+)
+
+const (
+	aggKeyPrefix  = "micro-dp:aggregations:"
+	aggIngestKey  = aggKeyPrefix + "ingest"
+	aggDLQKey     = aggKeyPrefix + "dlq"
+	aggSeenPrefix = aggKeyPrefix + "seen:"
+	aggSeenTTL    = 24 * time.Hour
+	aggDequeueWait = 5 * time.Second
+)
+
+type AggregationQueueImpl struct {
+	rdb *redis.Client
+}
+
+func NewAggregationQueue(client *ValkeyClient) *AggregationQueueImpl {
+	return &AggregationQueueImpl{rdb: client.Client()}
+}
+
+func (q *AggregationQueueImpl) Enqueue(ctx context.Context, msg domain.AggregationMessage) error {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("marshal aggregation message: %w", err)
+	}
+	return q.rdb.LPush(ctx, aggIngestKey, data).Err()
+}
+
+func (q *AggregationQueueImpl) Dequeue(ctx context.Context) (*domain.AggregationMessage, error) {
+	result, err := q.rdb.BRPop(ctx, aggDequeueWait, aggIngestKey).Result()
+	if err != nil {
+		if err == redis.Nil {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("dequeue aggregation: %w", err)
+	}
+
+	var msg domain.AggregationMessage
+	if err := json.Unmarshal([]byte(result[1]), &msg); err != nil {
+		return nil, fmt.Errorf("unmarshal aggregation message: %w", err)
+	}
+	return &msg, nil
+}
+
+func (q *AggregationQueueImpl) MarkProcessed(ctx context.Context, tenantID, date string) error {
+	key := aggSeenPrefix + tenantID + ":" + date
+	ok, err := q.rdb.SetArgs(ctx, key, "1", redis.SetArgs{
+		Mode: "NX",
+		TTL:  aggSeenTTL,
+	}).Result()
+	if err != nil && err != redis.Nil {
+		return fmt.Errorf("mark aggregation processed: %w", err)
+	}
+	if ok != "OK" {
+		return fmt.Errorf("aggregation already processed: %s:%s", tenantID, date)
+	}
+	return nil
+}
+
+func (q *AggregationQueueImpl) EnqueueDLQ(ctx context.Context, msg domain.AggregationMessage, reason string) error {
+	wrapper := struct {
+		Message domain.AggregationMessage `json:"message"`
+		Reason  string                    `json:"reason"`
+		Time    time.Time                 `json:"time"`
+	}{
+		Message: msg,
+		Reason:  reason,
+		Time:    time.Now().UTC(),
+	}
+	data, err := json.Marshal(wrapper)
+	if err != nil {
+		return fmt.Errorf("marshal aggregation dlq: %w", err)
+	}
+	return q.rdb.LPush(ctx, aggDLQKey, data).Err()
+}


### PR DESCRIPTION
## Summary
- `domain/aggregation_job.go`: `AggregationMessage` struct + `AggregationQueue` interface を追加
- `queue/aggregation_queue.go`: Valkey 実装 (Enqueue/Dequeue/MarkProcessed/EnqueueDLQ)
- 既存の EventQueue パターンを踏襲した集計パイプライン基盤

Closes #176

## Test plan
- [x] `go build ./...` 通過
- [ ] `make up && make health` でサービス起動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)