### PR TITLE
feat: migrate AggregationConsumer to BRPOP queue pattern

### DIFF
--- a/apps/golang/backend/cmd/worker/main.go
+++ b/apps/golang/backend/cmd/worker/main.go
@@ -126,10 +126,10 @@ func main() {
 	go jobRunConsumer.Run(ctx)
 
 	// Aggregation consumer (raw → events/visits)
-	tenantRepo := db.NewTenantRepo(sqlDB)
+	aggregationQueue := queue.NewAggregationQueue(valkeyClient)
 	aggregationWriter := worker.NewAggregationWriter(minioClient)
 	aggregationMetrics := observability.NewAggregationMetrics()
-	aggregationConsumer := worker.NewAggregationConsumer(tenantRepo, aggregationWriter, aggregationMetrics, 1*time.Hour)
+	aggregationConsumer := worker.NewAggregationConsumer(aggregationQueue, aggregationWriter, aggregationMetrics)
 
 	go aggregationConsumer.Run(ctx)
 

--- a/apps/golang/backend/domain/aggregation_job.go
+++ b/apps/golang/backend/domain/aggregation_job.go
@@ -1,6 +1,11 @@
 package domain
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+var ErrAggregationAlreadyProcessed = errors.New("aggregation already processed")
 
 type AggregationMessage struct {
 	TenantID string `json:"tenant_id"`

--- a/apps/golang/backend/internal/observability/aggregation_metrics.go
+++ b/apps/golang/backend/internal/observability/aggregation_metrics.go
@@ -8,6 +8,7 @@ import (
 type AggregationMetrics struct {
 	ProcessedTotal metric.Int64Counter
 	FailedTotal    metric.Int64Counter
+	DuplicateTotal metric.Int64Counter
 	Duration       metric.Float64Histogram
 }
 
@@ -18,12 +19,15 @@ func NewAggregationMetrics() *AggregationMetrics {
 		metric.WithDescription("Total aggregation runs completed"))
 	failed, _ := meter.Int64Counter("aggregation_failed_total",
 		metric.WithDescription("Total aggregation runs failed"))
+	duplicate, _ := meter.Int64Counter("aggregation_duplicate_total",
+		metric.WithDescription("Total aggregation runs skipped as duplicate"))
 	duration, _ := meter.Float64Histogram("aggregation_duration_seconds",
 		metric.WithDescription("Time to run an aggregation"))
 
 	return &AggregationMetrics{
 		ProcessedTotal: processed,
 		FailedTotal:    failed,
+		DuplicateTotal: duplicate,
 		Duration:       duration,
 	}
 }

--- a/apps/golang/backend/queue/aggregation_queue.go
+++ b/apps/golang/backend/queue/aggregation_queue.go
@@ -61,7 +61,7 @@ func (q *AggregationQueueImpl) MarkProcessed(ctx context.Context, tenantID, date
 		return fmt.Errorf("mark aggregation processed: %w", err)
 	}
 	if ok != "OK" {
-		return fmt.Errorf("aggregation already processed: %s:%s", tenantID, date)
+		return domain.ErrAggregationAlreadyProcessed
 	}
 	return nil
 }

--- a/apps/golang/backend/worker/aggregation_consumer.go
+++ b/apps/golang/backend/worker/aggregation_consumer.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"log"
 	"time"
 
@@ -10,71 +11,80 @@ import (
 )
 
 type AggregationConsumer struct {
-	tenants  domain.TenantRepository
-	writer   *AggregationWriter
-	metrics  *observability.AggregationMetrics
-	interval time.Duration
+	queue   domain.AggregationQueue
+	writer  *AggregationWriter
+	metrics *observability.AggregationMetrics
 }
 
 func NewAggregationConsumer(
-	tenants domain.TenantRepository,
+	queue domain.AggregationQueue,
 	writer *AggregationWriter,
 	metrics *observability.AggregationMetrics,
-	interval time.Duration,
 ) *AggregationConsumer {
 	return &AggregationConsumer{
-		tenants:  tenants,
-		writer:   writer,
-		metrics:  metrics,
-		interval: interval,
+		queue:   queue,
+		writer:  writer,
+		metrics: metrics,
 	}
 }
 
 func (c *AggregationConsumer) Run(ctx context.Context) {
-	log.Printf("aggregation consumer started (interval=%s)", c.interval)
-
-	// Run once on startup after a short delay
-	timer := time.NewTimer(10 * time.Second)
-	defer timer.Stop()
+	log.Println("aggregation consumer started")
 
 	for {
 		select {
 		case <-ctx.Done():
 			log.Println("aggregation consumer stopped")
 			return
-		case <-timer.C:
-			c.runAggregation(ctx)
-			timer.Reset(c.interval)
+		default:
+			msg, err := c.queue.Dequeue(ctx)
+			if err != nil {
+				if ctx.Err() != nil {
+					log.Println("aggregation consumer stopped")
+					return
+				}
+				log.Printf("aggregation dequeue error: %v", err)
+				continue
+			}
+			if msg == nil {
+				continue
+			}
+
+			c.processMessage(ctx, msg)
 		}
 	}
 }
 
-func (c *AggregationConsumer) runAggregation(ctx context.Context) {
-	tenants, err := c.tenants.ListAll(ctx)
-	if err != nil {
-		log.Printf("aggregation: list tenants error: %v", err)
+func (c *AggregationConsumer) processMessage(ctx context.Context, msg *domain.AggregationMessage) {
+	start := time.Now()
+
+	// Idempotency check
+	if err := c.queue.MarkProcessed(ctx, msg.TenantID, msg.Date); err != nil {
+		if errors.Is(err, domain.ErrAggregationAlreadyProcessed) {
+			log.Printf("aggregation: skipping duplicate tenant=%s date=%s", msg.TenantID, msg.Date)
+			c.metrics.DuplicateTotal.Add(ctx, 1)
+			return
+		}
+		log.Printf("aggregation: mark processed error tenant=%s date=%s: %v", msg.TenantID, msg.Date, err)
+		c.enqueueDLQ(ctx, msg, err.Error())
 		return
 	}
 
-	// Aggregate today's and yesterday's data
-	today := time.Now().UTC().Format("2006-01-02")
-	yesterday := time.Now().UTC().AddDate(0, 0, -1).Format("2006-01-02")
-	dates := []string{yesterday, today}
+	if err := c.writer.AggregateEvents(ctx, msg.TenantID, msg.Date); err != nil {
+		log.Printf("aggregation: tenant=%s date=%s error: %v", msg.TenantID, msg.Date, err)
+		c.metrics.FailedTotal.Add(ctx, 1)
+		c.enqueueDLQ(ctx, msg, err.Error())
+		return
+	}
 
-	for _, tenant := range tenants {
-		for _, date := range dates {
-			start := time.Now()
+	duration := time.Since(start)
+	c.metrics.ProcessedTotal.Add(ctx, 1)
+	c.metrics.Duration.Record(ctx, duration.Seconds())
+	log.Printf("aggregation: tenant=%s date=%s completed in %s", msg.TenantID, msg.Date, duration)
+}
 
-			if err := c.writer.AggregateEvents(ctx, tenant.ID, date); err != nil {
-				log.Printf("aggregation: tenant=%s date=%s error: %v", tenant.ID, date, err)
-				c.metrics.FailedTotal.Add(ctx, 1)
-				continue
-			}
-
-			duration := time.Since(start)
-			c.metrics.ProcessedTotal.Add(ctx, 1)
-			c.metrics.Duration.Record(ctx, duration.Seconds())
-			log.Printf("aggregation: tenant=%s date=%s completed in %s", tenant.ID, date, duration)
-		}
+func (c *AggregationConsumer) enqueueDLQ(ctx context.Context, msg *domain.AggregationMessage, reason string) {
+	if err := c.queue.EnqueueDLQ(ctx, *msg, reason); err != nil {
+		log.Printf("aggregation: enqueue dlq error tenant=%s date=%s: %v", msg.TenantID, msg.Date, err)
 	}
 }


### PR DESCRIPTION
## Summary
- Replace ticker-based `AggregationConsumer` with BRPOP queue-driven consumer following `upload_consumer` pattern
- Add `ErrAggregationAlreadyProcessed` sentinel error and idempotency check via `MarkProcessed`
- Add `aggregation_duplicate_total` metric, DLQ support for failed aggregations

Closes #177

## Test plan
- [x] `go build ./...` — backend and e2e-cli compile
- [x] `make up && make health` — all services healthy
- [x] Worker logs show `aggregation consumer started` (BRPOP mode)
- [x] `make e2e-cli` — all relevant tests pass (21/21)

🤖 Generated with [Claude Code](https://claude.com/claude-code)