### PR TITLE
feat: add aggregation backfill trigger API

### DIFF
--- a/apps/golang/backend/cmd/api/main.go
+++ b/apps/golang/backend/cmd/api/main.go
@@ -69,6 +69,7 @@ func main() {
 	}
 	defer valkeyClient.Close()
 	eventQueue := queue.NewEventQueue(valkeyClient)
+	aggregationQueue := queue.NewAggregationQueue(valkeyClient)
 
 	// Repositories
 	userRepo := db.NewUserRepo(sqlDB)
@@ -195,6 +196,7 @@ func main() {
 		jobRunRepo, jobVersionRepo, jobModuleRepo, transformQueue,
 	)
 	writeKeyService := usecase.NewWriteKeyService(writeKeyRepo, tenantRepo)
+	aggregationBackfillService := usecase.NewAggregationBackfillService(aggregationQueue, tenantRepo)
 	importJobService := usecase.NewImportJobService(jobService, jobRunService, moduleTypeRepo, jobVersionRepo, jobModuleRepo, connectionRepo)
 	dashboardService := usecase.NewDashboardService(dashboardRepo, dashboardWidgetRepo, chartRepo)
 	chartService := usecase.NewChartService(chartRepo, datasetRepo, minioClient)
@@ -227,6 +229,7 @@ func main() {
 	dashboardH := handler.NewDashboardHandler(dashboardService)
 	chartH := handler.NewChartHandler(chartService)
 	templateRunH := handler.NewTemplateRunHandler(templateRunService)
+	adminAggregationH := handler.NewAdminAggregationHandler(aggregationBackfillService)
 
 	// Middleware
 	authMW := handler.AuthMiddleware(jwtSecret)
@@ -392,6 +395,9 @@ func main() {
 	mux.Handle("POST /api/v1/admin/tenants", adminProtected(adminTenantH.Create))
 	mux.Handle("GET /api/v1/admin/tenants", adminProtected(adminTenantH.List))
 	mux.Handle("PATCH /api/v1/admin/tenants/{id}", adminProtected(adminTenantH.Patch))
+
+	// Admin aggregation
+	mux.Handle("POST /api/v1/admin/aggregations/backfill", adminProtected(adminAggregationH.TriggerBackfill))
 
 	// Admin plans
 	mux.Handle("POST /api/v1/admin/plans", adminProtected(adminPlanH.Create))

--- a/apps/golang/backend/domain/aggregation_job.go
+++ b/apps/golang/backend/domain/aggregation_job.go
@@ -16,5 +16,7 @@ type AggregationQueue interface {
 	Enqueue(ctx context.Context, msg AggregationMessage) error
 	Dequeue(ctx context.Context) (*AggregationMessage, error)
 	MarkProcessed(ctx context.Context, tenantID, date string) error
+	ResetProcessed(ctx context.Context, tenantID, date string) error
+	IsProcessed(ctx context.Context, tenantID, date string) (bool, error)
 	EnqueueDLQ(ctx context.Context, msg AggregationMessage, reason string) error
 }

--- a/apps/golang/backend/handler/admin_aggregation.go
+++ b/apps/golang/backend/handler/admin_aggregation.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/user/micro-dp/internal/openapi"
+	"github.com/user/micro-dp/usecase"
+)
+
+type AdminAggregationHandler struct {
+	backfill *usecase.AggregationBackfillService
+}
+
+func NewAdminAggregationHandler(backfill *usecase.AggregationBackfillService) *AdminAggregationHandler {
+	return &AdminAggregationHandler{backfill: backfill}
+}
+
+func (h *AdminAggregationHandler) TriggerBackfill(w http.ResponseWriter, r *http.Request) {
+	var req openapi.BackfillRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	startDate := req.StartDate.Time
+	endDate := req.EndDate.Time
+
+	if endDate.Before(startDate) {
+		writeError(w, http.StatusBadRequest, "end_date must be on or after start_date")
+		return
+	}
+
+	tenantID := ""
+	if req.TenantId != nil {
+		tenantID = *req.TenantId
+	}
+	force := false
+	if req.Force != nil {
+		force = *req.Force
+	}
+
+	result, err := h.backfill.TriggerBackfill(r.Context(), tenantID, startDate, endDate, force)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "backfill failed: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, openapi.BackfillResponse{
+		Enqueued: result.Enqueued,
+		Skipped:  result.Skipped,
+	})
+}

--- a/apps/golang/backend/internal/openapi/server.gen.go
+++ b/apps/golang/backend/internal/openapi/server.gen.go
@@ -17,6 +17,9 @@ import (
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// Trigger aggregation backfill (superadmin only)
+	// (POST /api/v1/admin/aggregations/backfill)
+	AdminTriggerBackfill(w http.ResponseWriter, r *http.Request)
 	// List plans (superadmin only)
 	// (GET /api/v1/admin/plans)
 	AdminListPlans(w http.ResponseWriter, r *http.Request)
@@ -303,6 +306,26 @@ type ServerInterfaceWrapper struct {
 }
 
 type MiddlewareFunc func(http.Handler) http.Handler
+
+// AdminTriggerBackfill operation middleware
+func (siw *ServerInterfaceWrapper) AdminTriggerBackfill(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.AdminTriggerBackfill(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
 
 // AdminListPlans operation middleware
 func (siw *ServerInterfaceWrapper) AdminListPlans(w http.ResponseWriter, r *http.Request) {
@@ -5084,6 +5107,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 		ErrorHandlerFunc:   options.ErrorHandlerFunc,
 	}
 
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1/admin/aggregations/backfill", wrapper.AdminTriggerBackfill)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/admin/plans", wrapper.AdminListPlans)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/admin/plans", wrapper.AdminCreatePlan)
 	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/admin/plans/{id}", wrapper.AdminUpdatePlan)
@@ -5181,6 +5205,50 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 }
 
 type ErrorResponseJSONResponse ErrorResponse
+
+type AdminTriggerBackfillRequestObject struct {
+	Body *AdminTriggerBackfillJSONRequestBody
+}
+
+type AdminTriggerBackfillResponseObject interface {
+	VisitAdminTriggerBackfillResponse(w http.ResponseWriter) error
+}
+
+type AdminTriggerBackfill200JSONResponse BackfillResponse
+
+func (response AdminTriggerBackfill200JSONResponse) VisitAdminTriggerBackfillResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminTriggerBackfill400JSONResponse struct{ ErrorResponseJSONResponse }
+
+func (response AdminTriggerBackfill400JSONResponse) VisitAdminTriggerBackfillResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminTriggerBackfill401JSONResponse ErrorResponse
+
+func (response AdminTriggerBackfill401JSONResponse) VisitAdminTriggerBackfillResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminTriggerBackfill403JSONResponse ErrorResponse
+
+func (response AdminTriggerBackfill403JSONResponse) VisitAdminTriggerBackfillResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
 
 type AdminListPlansRequestObject struct {
 }
@@ -8675,6 +8743,9 @@ func (response GetHealthz200JSONResponse) VisitGetHealthzResponse(w http.Respons
 
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
+	// Trigger aggregation backfill (superadmin only)
+	// (POST /api/v1/admin/aggregations/backfill)
+	AdminTriggerBackfill(ctx context.Context, request AdminTriggerBackfillRequestObject) (AdminTriggerBackfillResponseObject, error)
 	// List plans (superadmin only)
 	// (GET /api/v1/admin/plans)
 	AdminListPlans(ctx context.Context, request AdminListPlansRequestObject) (AdminListPlansResponseObject, error)
@@ -8980,6 +9051,37 @@ type strictHandler struct {
 	ssi         StrictServerInterface
 	middlewares []StrictMiddlewareFunc
 	options     StrictHTTPServerOptions
+}
+
+// AdminTriggerBackfill operation middleware
+func (sh *strictHandler) AdminTriggerBackfill(w http.ResponseWriter, r *http.Request) {
+	var request AdminTriggerBackfillRequestObject
+
+	var body AdminTriggerBackfillJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.AdminTriggerBackfill(ctx, request.(AdminTriggerBackfillRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "AdminTriggerBackfill")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(AdminTriggerBackfillResponseObject); ok {
+		if err := validResponse.VisitAdminTriggerBackfillResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
 }
 
 // AdminListPlans operation middleware

--- a/apps/golang/backend/internal/openapi/types.gen.go
+++ b/apps/golang/backend/internal/openapi/types.gen.go
@@ -189,6 +189,30 @@ type AssignPlanRequest struct {
 	PlanId string `json:"plan_id"`
 }
 
+// BackfillRequest defines model for BackfillRequest.
+type BackfillRequest struct {
+	// EndDate End date (YYYY-MM-DD)
+	EndDate openapi_types.Date `json:"end_date"`
+
+	// Force Force re-aggregation even if already processed
+	Force *bool `json:"force,omitempty"`
+
+	// StartDate Start date (YYYY-MM-DD)
+	StartDate openapi_types.Date `json:"start_date"`
+
+	// TenantId Target tenant ID (omit for all tenants)
+	TenantId *string `json:"tenant_id,omitempty"`
+}
+
+// BackfillResponse defines model for BackfillResponse.
+type BackfillResponse struct {
+	// Enqueued Number of aggregation jobs enqueued
+	Enqueued int `json:"enqueued"`
+
+	// Skipped Number of jobs skipped (already processed)
+	Skipped int `json:"skipped"`
+}
+
 // BillingSubscriptionResponse defines model for BillingSubscriptionResponse.
 type BillingSubscriptionResponse struct {
 	CurrentPeriodEnd     *time.Time `json:"current_period_end,omitempty"`
@@ -1487,6 +1511,9 @@ type DeleteWriteKeyParams struct {
 type RegenerateWriteKeyParams struct {
 	XTenantID XTenantID `json:"X-Tenant-ID"`
 }
+
+// AdminTriggerBackfillJSONRequestBody defines body for AdminTriggerBackfill for application/json ContentType.
+type AdminTriggerBackfillJSONRequestBody = BackfillRequest
 
 // AdminCreatePlanJSONRequestBody defines body for AdminCreatePlan for application/json ContentType.
 type AdminCreatePlanJSONRequestBody = CreatePlanRequest

--- a/apps/golang/backend/queue/aggregation_queue.go
+++ b/apps/golang/backend/queue/aggregation_queue.go
@@ -66,6 +66,20 @@ func (q *AggregationQueueImpl) MarkProcessed(ctx context.Context, tenantID, date
 	return nil
 }
 
+func (q *AggregationQueueImpl) ResetProcessed(ctx context.Context, tenantID, date string) error {
+	key := aggSeenPrefix + tenantID + ":" + date
+	return q.rdb.Del(ctx, key).Err()
+}
+
+func (q *AggregationQueueImpl) IsProcessed(ctx context.Context, tenantID, date string) (bool, error) {
+	key := aggSeenPrefix + tenantID + ":" + date
+	n, err := q.rdb.Exists(ctx, key).Result()
+	if err != nil {
+		return false, fmt.Errorf("check aggregation processed: %w", err)
+	}
+	return n > 0, nil
+}
+
 func (q *AggregationQueueImpl) EnqueueDLQ(ctx context.Context, msg domain.AggregationMessage, reason string) error {
 	wrapper := struct {
 		Message domain.AggregationMessage `json:"message"`

--- a/apps/golang/backend/usecase/aggregation.go
+++ b/apps/golang/backend/usecase/aggregation.go
@@ -1,0 +1,68 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/user/micro-dp/domain"
+)
+
+type AggregationBackfillService struct {
+	queue   domain.AggregationQueue
+	tenants domain.TenantRepository
+}
+
+func NewAggregationBackfillService(queue domain.AggregationQueue, tenants domain.TenantRepository) *AggregationBackfillService {
+	return &AggregationBackfillService{queue: queue, tenants: tenants}
+}
+
+type BackfillResult struct {
+	Enqueued int
+	Skipped  int
+}
+
+func (s *AggregationBackfillService) TriggerBackfill(ctx context.Context, tenantID string, startDate, endDate time.Time, force bool) (*BackfillResult, error) {
+	var tenantIDs []string
+	if tenantID != "" {
+		tenantIDs = []string{tenantID}
+	} else {
+		tenants, err := s.tenants.ListAll(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("list tenants: %w", err)
+		}
+		for _, t := range tenants {
+			tenantIDs = append(tenantIDs, t.ID)
+		}
+	}
+
+	result := &BackfillResult{}
+	for d := startDate; !d.After(endDate); d = d.AddDate(0, 0, 1) {
+		date := d.Format("2006-01-02")
+		for _, tid := range tenantIDs {
+			if force {
+				if err := s.queue.ResetProcessed(ctx, tid, date); err != nil {
+					log.Printf("reset processed error tenant=%s date=%s: %v", tid, date, err)
+				}
+			} else {
+				processed, err := s.queue.IsProcessed(ctx, tid, date)
+				if err != nil {
+					log.Printf("check processed error tenant=%s date=%s: %v", tid, date, err)
+				}
+				if processed {
+					result.Skipped++
+					continue
+				}
+			}
+
+			msg := domain.AggregationMessage{TenantID: tid, Date: date}
+			if err := s.queue.Enqueue(ctx, msg); err != nil {
+				return nil, fmt.Errorf("enqueue backfill tenant=%s date=%s: %w", tid, date, err)
+			}
+			result.Enqueued++
+		}
+	}
+
+	return result, nil
+}

--- a/apps/golang/e2e-cli/internal/openapi/types.gen.go
+++ b/apps/golang/e2e-cli/internal/openapi/types.gen.go
@@ -189,6 +189,30 @@ type AssignPlanRequest struct {
 	PlanId string `json:"plan_id"`
 }
 
+// BackfillRequest defines model for BackfillRequest.
+type BackfillRequest struct {
+	// EndDate End date (YYYY-MM-DD)
+	EndDate openapi_types.Date `json:"end_date"`
+
+	// Force Force re-aggregation even if already processed
+	Force *bool `json:"force,omitempty"`
+
+	// StartDate Start date (YYYY-MM-DD)
+	StartDate openapi_types.Date `json:"start_date"`
+
+	// TenantId Target tenant ID (omit for all tenants)
+	TenantId *string `json:"tenant_id,omitempty"`
+}
+
+// BackfillResponse defines model for BackfillResponse.
+type BackfillResponse struct {
+	// Enqueued Number of aggregation jobs enqueued
+	Enqueued int `json:"enqueued"`
+
+	// Skipped Number of jobs skipped (already processed)
+	Skipped int `json:"skipped"`
+}
+
 // BillingSubscriptionResponse defines model for BillingSubscriptionResponse.
 type BillingSubscriptionResponse struct {
 	CurrentPeriodEnd     *time.Time `json:"current_period_end,omitempty"`
@@ -1487,6 +1511,9 @@ type DeleteWriteKeyParams struct {
 type RegenerateWriteKeyParams struct {
 	XTenantID XTenantID `json:"X-Tenant-ID"`
 }
+
+// AdminTriggerBackfillJSONRequestBody defines body for AdminTriggerBackfill for application/json ContentType.
+type AdminTriggerBackfillJSONRequestBody = BackfillRequest
 
 // AdminCreatePlanJSONRequestBody defines body for AdminCreatePlan for application/json ContentType.
 type AdminCreatePlanJSONRequestBody = CreatePlanRequest

--- a/apps/node/web/src/lib/api/generated.ts
+++ b/apps/node/web/src/lib/api/generated.ts
@@ -397,6 +397,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/admin/aggregations/backfill": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Trigger aggregation backfill (superadmin only) */
+        post: operations["adminTriggerBackfill"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/jobs": {
         parameters: {
             query?: never;
@@ -1731,6 +1748,31 @@ export interface components {
             max_rows_per_day?: number;
             max_uploads_per_day?: number;
         };
+        BackfillRequest: {
+            /** @description Target tenant ID (omit for all tenants) */
+            tenant_id?: string;
+            /**
+             * Format: date
+             * @description Start date (YYYY-MM-DD)
+             */
+            start_date: string;
+            /**
+             * Format: date
+             * @description End date (YYYY-MM-DD)
+             */
+            end_date: string;
+            /**
+             * @description Force re-aggregation even if already processed
+             * @default false
+             */
+            force: boolean;
+        };
+        BackfillResponse: {
+            /** @description Number of aggregation jobs enqueued */
+            enqueued: number;
+            /** @description Number of jobs skipped (already processed) */
+            skipped: number;
+        };
         AssignPlanRequest: {
             plan_id: string;
         };
@@ -2653,6 +2695,33 @@ export interface operations {
             401: components["responses"]["ErrorResponse"];
             403: components["responses"]["ErrorResponse"];
             404: components["responses"]["ErrorResponse"];
+        };
+    };
+    adminTriggerBackfill: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BackfillRequest"];
+            };
+        };
+        responses: {
+            /** @description Backfill jobs enqueued */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BackfillResponse"];
+                };
+            };
+            400: components["responses"]["ErrorResponse"];
+            401: components["responses"]["ErrorResponse"];
+            403: components["responses"]["ErrorResponse"];
         };
     };
     listJobs: {

--- a/spec/openapi/v1.yaml
+++ b/spec/openapi/v1.yaml
@@ -656,6 +656,34 @@ paths:
         "404":
           $ref: "#/components/responses/ErrorResponse"
 
+  # ---- Aggregation Backfill ----
+  /api/v1/admin/aggregations/backfill:
+    post:
+      tags: [admin]
+      summary: Trigger aggregation backfill (superadmin only)
+      operationId: adminTriggerBackfill
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BackfillRequest"
+      responses:
+        "200":
+          description: Backfill jobs enqueued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BackfillResponse"
+        "400":
+          $ref: "#/components/responses/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/ErrorResponse"
+        "403":
+          $ref: "#/components/responses/ErrorResponse"
+
   # ---- Jobs ----
   /api/v1/jobs:
     post:
@@ -3558,6 +3586,36 @@ components:
           type: integer
         max_uploads_per_day:
           type: integer
+    # ---- Aggregation Backfill ----
+    BackfillRequest:
+      type: object
+      required: [start_date, end_date]
+      properties:
+        tenant_id:
+          type: string
+          description: Target tenant ID (omit for all tenants)
+        start_date:
+          type: string
+          format: date
+          description: Start date (YYYY-MM-DD)
+        end_date:
+          type: string
+          format: date
+          description: End date (YYYY-MM-DD)
+        force:
+          type: boolean
+          default: false
+          description: Force re-aggregation even if already processed
+    BackfillResponse:
+      type: object
+      required: [enqueued, skipped]
+      properties:
+        enqueued:
+          type: integer
+          description: Number of aggregation jobs enqueued
+        skipped:
+          type: integer
+          description: Number of jobs skipped (already processed)
     AssignPlanRequest:
       type: object
       required: [plan_id]


### PR DESCRIPTION
## Summary
- Added `POST /api/v1/admin/aggregations/backfill` endpoint (superadmin only)
- Accepts `tenant_id` (optional, all tenants if omitted), `start_date`, `end_date`, `force` (boolean)
- Enqueues `AggregationMessage` per tenant+date into existing BRPOP queue
- Duplicate control: `force=false` skips already-processed jobs, `force=true` resets seen keys for re-aggregation
- Added `ResetProcessed` and `IsProcessed` to `AggregationQueue` interface + Valkey implementation

Closes #134

## Test plan
- [x] `make openapi-lint` passes
- [x] `make openapi-generate` produces consistent output
- [x] `go build ./...` for backend and e2e-cli
- [x] Verified: initial backfill → `enqueued: 3, skipped: 0`
- [x] Verified: duplicate request → `enqueued: 0, skipped: 3`
- [x] Verified: force=true → `enqueued: 3, skipped: 0`
- [x] Verified: date validation → `400 error`
- [x] Verified: non-superadmin → `403 forbidden`

🤖 Generated with [Claude Code](https://claude.com/claude-code)